### PR TITLE
Set box expansion value on `GeometryUserData`

### DIFF
--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -92,6 +92,7 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
     this->surface_to_geometry_map_[surface] = surface_geometry;
 
     std::shared_ptr<GeometryUserData> surface_data = std::make_shared<GeometryUserData>();
+    surface_data->box_bump = bump;
     surface_data->surface_id = surface;
     surface_data->mesh_manager = mesh_manager.get();
     surface_data->prim_ref_buffer = tri_ref_ptr + buffer_start;

--- a/tests/test_point_in_volume.cpp
+++ b/tests/test_point_in_volume.cpp
@@ -31,12 +31,13 @@ TEST_CASE("Test Point in Volume")
   result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == true);
 
-  // test a point on the positive x boundary
-  point = {5.0, 0.0, 0,0};
+  // test a point just outside on the positive x boundary
+  // no direction
+  point = {5.001, 0.0, 0,0};
   result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == false);
 
-  // test a point just outside the positive x boundary
+  // test a point on the positive x boundary
   // and provide a direction
   point = {5.0, 0.0, 0.0};
   Direction dir = {1.0, 0.0, 0.0};


### PR DESCRIPTION
The box expansion value was being computed but no applied. When using mixed-precision algorithms, it's good to ensure that the measures of protection for false negatives are properly applied 🤦🏻 Found this when benchmarking XDG in an OpenMC run.