### PR TITLE
Use minimal bump value

### DIFF
--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -80,7 +80,6 @@ RayTracer::register_volume(const std::shared_ptr<MeshManager> mesh_manager,
   double max_distance = std::sqrt(dx*dx + dy*dy + dz*dz);
   double bump = max_distance * std::pow(10, -std::numeric_limits<float>::digits10);
   bump = std::max(bump, 1e-03);
-  bump = 1.0;
 
   // create a new geometry for each surface
   int buffer_start = 0;


### PR DESCRIPTION
#53 fixed a robustness problem, but introduced a performance problem by setting the box expansion value (a.k.a. `bump` variable) to 1.0. Not a great idea as this can cause significant overlap of bounding boxes, many false positive tests during BHV traversal, and performance degredation. 

This PR simply sets it to the intended value (the minimum of 1e-03 and the length of the bounding box diagonal for the problem at hand). This should resolve the issue reported in #4. Thanks again for catching this quickly @Waqar-ukaea!

