### PR TITLE
Allow raytracer setup for a single volume

### DIFF
--- a/include/xdg/xdg.h
+++ b/include/xdg/xdg.h
@@ -25,6 +25,8 @@ public:
 // Methods
   void prepare_raytracer();
 
+  void prepare_volume_for_raytracing(MeshID volume);
+
 // Geometric Queries
 MeshID find_volume(const Position& point,
                    const Direction& direction) const;

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -12,11 +12,14 @@ namespace xdg {
 void XDG::prepare_raytracer()
 {
   for (auto volume : mesh_manager()->volumes()) {
-    TreeID tree = ray_tracing_interface_->register_volume(mesh_manager_, volume);
-    volume_to_scene_map_[volume] = tree;
+    this->prepare_volume_for_raytracing(volume);
   }
 }
 
+void XDG::prepare_volume_for_raytracing(MeshID volume) {
+    TreeID tree = ray_tracing_interface_->register_volume(mesh_manager_, volume);
+    volume_to_scene_map_[volume] = tree;
+}
 
 std::shared_ptr<XDG> XDG::create(MeshLibrary library)
 {

--- a/tools/ray_fire.cpp
+++ b/tools/ray_fire.cpp
@@ -52,7 +52,6 @@ int main(int argc, char** argv) {
   mm->load_file(args.get<std::string>("filename"));
   mm->init();
   mm->parse_metadata();
-  xdg->prepare_raytracer();
 
   if (args.get<bool>("--list")) {
     std::cout << "Volumes: " << std::endl;
@@ -63,8 +62,14 @@ int main(int argc, char** argv) {
   }
 
   MeshID volume = args.get<int>("volume");
+  xdg->prepare_volume_for_raytracing(volume);
+
   Position origin = args.get<std::vector<double>>("--origin");
   Direction direction = args.get<std::vector<double>>("--direction");
+  direction.normalize();
+
+  std::cout << "Origin: " << origin[0] << ", " << origin[1] << ", " << origin[2] << std::endl;
+  std::cout << "Direction: " << direction[0] << ", " << direction[1] << ", " << direction[2] << std::endl;
 
   auto result = xdg->ray_fire(volume, origin, direction);
 


### PR DESCRIPTION
This is a minor refactor of the `XDG::prepare_raytracer` method that allows a single volume to be prepped. This is useful in tools like `ray_fire` where we really only need to build the BVH for a single volume. It should improve the responsiveness of such tools.