### PR TITLE
Threaded (and general) performance-related changed

### DIFF
--- a/include/xdg/xdg.h
+++ b/include/xdg/xdg.h
@@ -2,6 +2,7 @@
 #define _XDG_INTERFACE_H
 
 #include <memory>
+#include <unordered_map>
 
 #include "xdg/mesh_manager_interface.h"
 #include "xdg/ray_tracing_interface.h"
@@ -69,7 +70,7 @@ Direction surface_normal(MeshID surface,
   }
 
 // Accessors
-  const std::shared_ptr<RayTracer> ray_tracing_interface() const {
+  const std::shared_ptr<RayTracer>& ray_tracing_interface() const {
     return ray_tracing_interface_;
   }
 
@@ -85,9 +86,9 @@ private:
   const std::shared_ptr<RayTracer> ray_tracing_interface_ {std::make_shared<RayTracer>()};
   std::shared_ptr<MeshManager> mesh_manager_ {nullptr};
 
-  std::map<MeshID, TreeID> volume_to_scene_map_;  //<! Map from mesh volume to embree scene
-  std::map<MeshID, TreeID> surface_to_scene_map_; //<! Map from mesh surface to embree scnee
-  std::map<MeshID, RTCGeometry> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
+  std::unordered_map<MeshID, TreeID> volume_to_scene_map_;  //<! Map from mesh volume to embree scene
+  std::unordered_map<MeshID, TreeID> surface_to_scene_map_; //<! Map from mesh surface to embree scnee
+  std::unordered_map<MeshID, RTCGeometry> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
   TreeID gloabal_scene_;
 };
 


### PR DESCRIPTION
This PR contains performance-critical updates for threaded (and non-threaded) scaling.

The change that affects threaded scalability is the update of the ray tracer accessor method to return a reference to the existing shared pointer instead of a shared pointer. Nothing is wrong with this in terms of behavior, but that object can't be operated on while a new shared pointer object is being created.

There's also an update to some of the XDG geometry to raytracer mapping from `std::map` to `std::unordered_map`. These structures are hit very often in ray queries and the O(1) lookup time from the hash table is needed.