### PR TITLE
Adding micro-benchmarks to XDG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          ctest -j4 --output-on-failure
+          ctest -j4 --output-on-failure --verbose
 
       - name: Check installed executables
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          ctest -j4 --output-on-failure --verbose
+          ctest -j1 --output-on-failure --verbose
 
       - name: Check installed executables
         shell: bash

--- a/tests/test_point_in_volume.cpp
+++ b/tests/test_point_in_volume.cpp
@@ -4,6 +4,8 @@
 // xdg includes
 #include "xdg/mesh_manager_interface.h"
 #include "xdg/ray_tracing_interface.h"
+#include <catch2/benchmark/catch_benchmark.hpp>
+
 
 #include "mesh_mock.h"
 
@@ -22,9 +24,17 @@ TEST_CASE("Test Point in Volume")
   bool result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == true);
 
+  BENCHMARK("point_in_vol [Inside]"){
+    return rti->point_in_volume(volume_tree, point);
+  };
+
   point = {0.0, 0.0, 1000.0};
   result = rti->point_in_volume(volume_tree, point);
   REQUIRE(result == false);
+
+  BENCHMARK("point_in_vol [Outside]"){
+    return rti->point_in_volume(volume_tree, point);
+  };
 
   // test a point just inside the positive x boundary
   point = {4.0 - 1e-06, 0.0, 0.0};

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -30,7 +30,8 @@ TEST_CASE("Test Ray Fire Mesh Mock")
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
 
-  BENCHMARK("ray_fire_1"){
+  // benchmark firing from inside the cube to a face
+  BENCHMARK("ray_fire_from_inside"){
     return rti->ray_fire(volume_tree, origin, direction);
   };
 
@@ -61,6 +62,10 @@ TEST_CASE("Test Ray Fire Mesh Mock")
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(15.0, 1e-6));
 
+  BENCHMARK("ray_fire_from_outside_vol [Exiting]"){
+    return rti->ray_fire(volume_tree, origin, direction);
+  };
+
   origin = {10.0, 0.0, 0.0};
   direction = {-1.0, 0.0, 0.0};
   intersection = rti->ray_fire(volume_tree, origin, direction);
@@ -72,6 +77,10 @@ TEST_CASE("Test Ray Fire Mesh Mock")
   direction = {1.0, 0.0, 0.0};
   intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, HitOrientation::ENTERING);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(8.0, 1e-6));
+
+  BENCHMARK("ray_fire_from_outside_vol [Entering]"){
+    return rti->ray_fire(volume_tree, origin, direction);
+  };
 
   origin = {10.0, 0.0, 0.0};
   direction = {-1.0, 0.0, 0.0};

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -35,6 +35,13 @@ TEST_CASE("Test Ray Fire Mesh Mock")
     return rti->ray_fire(volume_tree, origin, direction);
   };
 
+  // advanced benchmark
+  BENCHMARK_ADVANCED("Advanced ray_fire benchmark")(Catch::Benchmark::Chronometer meter){
+    meter.measure([]{
+      return rti->ray_fire(volume_tree, origin, direction);
+    });
+  };
+
   direction *= -1;
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(2.0, 1e-6));

--- a/tests/test_ray_fire.cpp
+++ b/tests/test_ray_fire.cpp
@@ -2,6 +2,7 @@
 // for testing
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
 
 // xdg includes
 #include "xdg/constants.h"
@@ -28,6 +29,10 @@ TEST_CASE("Test Ray Fire Mesh Mock")
   // fire from the origin toward each face, ensuring that the intersection distances are correct
   intersection = rti->ray_fire(volume_tree, origin, direction);
   REQUIRE_THAT(intersection.first, Catch::Matchers::WithinAbs(5.0, 1e-6));
+
+  BENCHMARK("ray_fire_1"){
+    return rti->ray_fire(volume_tree, origin, direction);
+  };
 
   direction *= -1;
   intersection = rti->ray_fire(volume_tree, origin, direction);
@@ -98,3 +103,18 @@ TEST_CASE("Test Ray Fire Mesh Mock")
   intersection = rti->ray_fire(volume_tree, origin, direction, INFTY, HitOrientation::EXITING, &exclude_primitives);
   REQUIRE(intersection.second == ID_NONE);
 }
+
+
+// TEST_CASE("Micro-Benchmark ray_fire()")
+// {
+//   std::shared_ptr<MeshManager> mm = std::make_shared<MeshMock>();
+//   mm->init(); // this should do nothing, just good practice to call it
+//   REQUIRE(mm->mesh_library() == MeshLibrary::INTERNAL);
+
+//   std::shared_ptr<RayTracer> rti = std::make_shared<RayTracer>();
+//   TreeID volume_tree = rti->register_volume(mm, mm->volumes()[0]);
+
+//   Position origin {0.0, 0.0, 0.0};
+//   Direction direction {1.0, 0.0, 0.0};
+//   std::pair<double, MeshID> intersection;
+// }


### PR DESCRIPTION
I think it would be a good idea if XDG also implemented micro-benchmarks alongside its unit tests for the various ray tracing operations so that we have a record of performance of these operations when code changes are made. 

This PR aims to add some micro-benchmarks for each of the ray tracing operations currently available in XDG. Catch2 supports benchmarking natively so I was thinking we could just go ahead and use the Catch2 macros rather than bringing in another library. Details of how to implement benchmarks with Catch2 can be found here - https://github.com/catchorg/Catch2/blob/devel/docs/benchmarks.md 

If we want more advanced benchmarking control something like https://github.com/google/benchmark may be more suitable though.

Some other considerations:
- We can just add some benchmarks to the existing test cases but it might make more sense to define some simple geometry/problems explicitly for benchmarking purposes.
- Each additional benchmark will ofc increase the time it takes for the CI to complete so will have to think about the length of these benchmarks and how many we actually need. 
- How these benchmarks actually interact with the CI will also need to be considered. Should large performance drops block merging for example.
- Perhaps these benchmarks could also be extended to some of the mesh operations too.
- Ctest by default won't display benchmark results unless called with `--verbose` as a benchmark won't count as failing.
- Benchmarking results could be logged to seperate file and used for analysis in within the workflow but could also be stored as github artifacts to allow some persistent history. (Probably makes sense for an artifact-based workflow to only be triggered on merges into main)