### PR TITLE
Check that HDF5 is enabled if using MOAB 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ endif()
 #===============================================================================
 if (XDG_ENABLE_MOAB)
 find_package(MOAB REQUIRED HINTS ${MOAB_DIR})
+if (NOT MOAB_USE_HDF5)
+  message(FATAL_ERROR "MOAB must be built with HDF5 support for file specifications required by XDG.")
+endif()
 endif()
 
 if (XDG_ENABLE_EMBREE)
@@ -62,7 +65,7 @@ if (XDG_ENABLE_EMBREE)
   endif()
 
   message(STATUS "Found Embree ${EMBREE_VERSION} at ${EMBREE_ROOT_DIR}")
-endif()  
+endif()
 
 # Catch2 testing module
 if (XDG_BUILD_TESTS)


### PR DESCRIPTION
DAGMC (and in turn XDG's MOAB backend) rely on files in its native HDF5 file format (`.h5m`).

No sense in compiling against a MOAB without this file format enabled, so we can catch this early during CMake configuration.