### PR TITLE
Adding an fmt::formatter for the Vec3da type

### DIFF
--- a/include/xdg/ray.h
+++ b/include/xdg/ray.h
@@ -7,8 +7,6 @@
 
 #include "xdg/vec3da.h"
 
-#include <fmt/format.h>
-
 #include "xdg/constants.h"
 #include "xdg/embree_interface.h"
 
@@ -148,18 +146,5 @@ struct RTCDPointQuery : RTCPointQuery {
 
 } // namespace xdg
 
-namespace fmt {
-
-template<>
-struct formatter<xdg::Vec3da> : formatter<std::string> {
-  template<typename FormatContext>
-  auto format(const xdg::Vec3da& v, FormatContext& ctx)
-  {
-    return formatter<std::string>::format(
-      fmt::format("({}, {}, {})", v.x, v.y, v.z), ctx);
-  }
-};
-
-} // namespace fmt
 
 #endif // include guard

--- a/include/xdg/vec3da.h
+++ b/include/xdg/vec3da.h
@@ -17,6 +17,8 @@
 #define __forceinline inline __attribute__((always_inline))
 #endif
 
+#include <fmt/format.h>
+
 #include "xdg/constants.h"
 
 namespace xdg {
@@ -175,18 +177,15 @@ inline Direction rand_dir() {
 
 } // end namespace xdg
 
-namespace fmt{
-template <>
-struct formatter<xdg::Vec3da> {
-    template <typename ParseContext>
-    constexpr auto parse(ParseContext& ctx) {
-        return ctx.begin();
-    }
-
-    template <typename FormatContext>
-    auto format(const xdg::Vec3da& v, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "[{}, {}, {}]", v.x, v.y, v.z);
-    }
+namespace fmt {
+template<>
+struct formatter<xdg::Vec3da> : formatter<std::string> {
+  template<typename FormatContext>
+  auto format(const xdg::Vec3da& v, FormatContext& ctx)
+  {
+    return formatter<std::string>::format(
+      fmt::format("({}, {}, {})", v.x, v.y, v.z), ctx);
+  }
 };
 
 } // end namespace fmt

--- a/include/xdg/vec3da.h
+++ b/include/xdg/vec3da.h
@@ -173,7 +173,22 @@ inline Direction rand_dir() {
 
 }
 
-
 } // end namespace xdg
 
-#endif
+namespace fmt{
+template <>
+struct formatter<xdg::Vec3da> {
+    template <typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(const xdg::Vec3da& v, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "[{}, {}, {}]", v.x, v.y, v.z);
+    }
+};
+
+} // end namespace fmt
+
+#endif // include guard


### PR DESCRIPTION
This adds a method that makes generating `fmt` messages with `Vec3da` objects much easier.