### PR TITLE
Adding new methods to the BoundingBox class and more tests

### DIFF
--- a/include/xdg/bbox.h
+++ b/include/xdg/bbox.h
@@ -1,8 +1,10 @@
 #ifndef _XDG_BOUNDING_BOX_H
 #define _XDG_BOUNDING_BOX_H
 
-#include "xdg/vec3da.h"
 #include <fmt/format.h>
+
+#include "xdg/constants.h"
+#include "xdg/vec3da.h"
 namespace xdg {
 
 union BoundingBox {
@@ -94,7 +96,7 @@ double max_chord_length() const {
  * @return double The dilation distance
  */
 double dilation() const {
-  return max_chord_length() * std::pow(10, -std::numeric_limits<float>::digits10);
+  return max_chord_length() * DILATION_FACTOR;
 }
 
 template <typename T>

--- a/include/xdg/bbox.h
+++ b/include/xdg/bbox.h
@@ -78,7 +78,7 @@ bool contains(const Position& p) const {
          p.z >= min_z && p.z <= max_z;
 }
 
-double maximum_chord_length() const {
+double max_chord_length() const {
   Vec3da w = width();
   double max_chord = std::sqrt(w.dot(w));
   return max_chord * std::pow(10, -std::numeric_limits<float>::digits10);

--- a/include/xdg/bbox.h
+++ b/include/xdg/bbox.h
@@ -80,8 +80,21 @@ bool contains(const Position& p) const {
 
 double max_chord_length() const {
   Vec3da w = width();
-  double max_chord = std::sqrt(w.dot(w));
-  return max_chord * std::pow(10, -std::numeric_limits<float>::digits10);
+  return  std::sqrt(w.dot(w));
+}
+
+/**
+ * @brief Returns a distance by which the box should be dilated to account for mixed precision effects
+ *
+ * This method calculates a small distance that can be used to dilate the bounding box
+ * to account for potential numerical precision issues when working with mixed precision
+ * calculations. The distance is based on the maximum chord length of the box and the
+ * precision of float values.
+ *
+ * @return double The dilation distance
+ */
+double dilation() const {
+  return max_chord_length() * std::pow(10, -std::numeric_limits<float>::digits10);
 }
 
 template <typename T>

--- a/include/xdg/constants.h
+++ b/include/xdg/constants.h
@@ -1,6 +1,7 @@
 #ifndef _XDG_CONSTANTS
 #define _XDG_CONSTANTS
 
+#include <cmath>
 #include <map>
 #include <limits>
 #include <string>
@@ -18,6 +19,8 @@ constexpr double INFTY {std::numeric_limits<double>::max()};
 #else
   constexpr double INFTYF {std::numeric_limits<float>::max()};
 #endif
+
+constexpr double DILATION_FACTOR {std::pow(10, -std::numeric_limits<float>::digits10)};
 
 // Whether information pertains to a surface or volume
 enum class GeometryType {

--- a/src/ray_tracing_interface.cpp
+++ b/src/ray_tracing_interface.cpp
@@ -18,21 +18,10 @@ TreeID RayTracer::next_tree_id() const
   return *std::max_element(tree_ids.begin(), tree_ids.end()) + 1;
 }
 
-  const double RayTracer::bounding_box_bump(const std::shared_ptr<MeshManager> mesh_manager, MeshID volume_id)
-  {
-    // compute the bounding box of the volume
-    auto volume_bounding_box = mesh_manager->volume_bounding_box(volume_id);
-
-    // determine the bump distance for this volume based on the maximum distance a ray will travel
-    // to an intersection
-    double dx = volume_bounding_box.max_x - volume_bounding_box.min_x;
-    double dy = volume_bounding_box.max_y - volume_bounding_box.min_y;
-    double dz = volume_bounding_box.max_z - volume_bounding_box.min_z;
-
-    double max_distance = std::sqrt(dx*dx + dy*dy + dz*dz);
-    double bump = max_distance * std::pow(10, -std::numeric_limits<float>::digits10);
-    bump = std::max(bump, numerical_precision_);
-
-    return bump;
-  }
+const double RayTracer::bounding_box_bump(const std::shared_ptr<MeshManager> mesh_manager, MeshID volume_id)
+{
+  auto volume_bounding_box = mesh_manager->volume_bounding_box(volume_id);
+  return std::max(volume_bounding_box.dilation(), numerical_precision_);
 }
+
+} // namespace xdg

--- a/tests/test_bbox.cpp
+++ b/tests/test_bbox.cpp
@@ -4,7 +4,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
-#include <catch2/catch_approx.hpp>
 
 // xdg includes
 #include "xdg/bbox.h"
@@ -44,15 +43,15 @@ TEST_CASE("Test BoundingBox")
 
   // Test center() method
   Position center = c.center();
-  REQUIRE(center.x == Catch::Approx(1.5));
-  REQUIRE(center.y == Catch::Approx(1.5));
-  REQUIRE(center.z == Catch::Approx(1.5));
+  REQUIRE(center.x == 1.5);
+  REQUIRE(center.y == 1.5);
+  REQUIRE(center.z == 1.5);
 
   // Test width() method
   Vec3da width = c.width();
-  REQUIRE(width.x == Catch::Approx(7.0));
-  REQUIRE(width.y == Catch::Approx(9.0));
-  REQUIRE(width.z == Catch::Approx(11.0));
+  REQUIRE(width.x == 7.0);
+  REQUIRE(width.y == 9.0);
+  REQUIRE(width.z == 11.0);
 
   // Test lower_left() method
   Position lower = c.lower_left();
@@ -73,15 +72,15 @@ TEST_CASE("Test BoundingBox")
   REQUIRE_FALSE(c.contains(outside));
 
   // Test max_chord_length() method
-  REQUIRE(a.max_chord_length() == Catch::Approx(std::sqrt(3.0)));
-  REQUIRE(b.max_chord_length() == Catch::Approx(std::sqrt(3.0)));
+  REQUIRE(a.max_chord_length() == std::sqrt(3.0));
+  REQUIRE(b.max_chord_length() == std::sqrt(3.0));
   // box c at this point is 7x9x11
-  REQUIRE(c.max_chord_length() == Catch::Approx(std::sqrt(49.0 + 81.0 + 121.0)));
+  REQUIRE(c.max_chord_length() == std::sqrt(49.0 + 81.0 + 121.0));
 
   // Test dilation() method
-  REQUIRE(a.dilation() == Catch::Approx(std::sqrt(3.0) * std::pow(10, -std::numeric_limits<float>::digits10)));
-  REQUIRE(b.dilation() == Catch::Approx(std::sqrt(3.0) * std::pow(10, -std::numeric_limits<float>::digits10)));
-  REQUIRE(c.dilation() == Catch::Approx(std::sqrt(49.0 + 81.0 + 121.0) * std::pow(10, -std::numeric_limits<float>::digits10)));
+  REQUIRE(a.dilation() == std::sqrt(3.0) * std::pow(10, -std::numeric_limits<float>::digits10));
+  REQUIRE(b.dilation() == std::sqrt(3.0) * std::pow(10, -std::numeric_limits<float>::digits10));
+  REQUIRE(c.dilation() == std::sqrt(49.0 + 81.0 + 121.0) * std::pow(10, -std::numeric_limits<float>::digits10));
 
   // Test from_points() static method
   std::vector<Position> points = {
@@ -104,18 +103,18 @@ TEST_CASE("Test BoundingBox")
 
   // Stress test with large numbers
   BoundingBox large_box{1e10, 1e10, 1e10, 2e10, 2e10, 2e10};
-  REQUIRE(large_box.width().x == Catch::Approx(1e10));
-  REQUIRE(large_box.center().x == Catch::Approx(1.5e10));
+  REQUIRE(large_box.width().x == 1e10);
+  REQUIRE(large_box.center().x == 1.5e10);
 
   // Stress test with very small numbers
   BoundingBox small_box{1e-10, 1e-10, 1e-10, 2e-10, 2e-10, 2e-10};
-  REQUIRE(small_box.width().x == Catch::Approx(1e-10));
-  REQUIRE(small_box.center().x == Catch::Approx(1.5e-10));
+  REQUIRE(small_box.width().x == 1e-10);
+  REQUIRE(small_box.center().x == 1.5e-10);
 
   // Stress test with mixed positive/negative numbers
   BoundingBox mixed_box{-1e10, -1e10, -1e10, 1e10, 1e10, 1e10};
-  REQUIRE(mixed_box.width().x == Catch::Approx(2e10));
-  REQUIRE(mixed_box.center().x == Catch::Approx(0.0));
+  REQUIRE(mixed_box.width().x == 2e10);
+  REQUIRE(mixed_box.center().x == 0.0);
   REQUIRE(mixed_box.min_x == -1e10);
   REQUIRE(mixed_box.min_y == -1e10);
   REQUIRE(mixed_box.min_z == -1e10);
@@ -127,8 +126,8 @@ TEST_CASE("Test BoundingBox")
   BoundingBox stress_box;
   stress_box.update(Position{1e20, 1e20, 1e20});
   stress_box.update(Position{-1e20, -1e20, -1e20});
-  REQUIRE(stress_box.width().x == Catch::Approx(2e20));
-  REQUIRE(stress_box.center().x == Catch::Approx(0.0));
+  REQUIRE(stress_box.width().x == 2e20);
+  REQUIRE(stress_box.center().x == 0.0);
 
   // Stress test from_points() with many points
   std::vector<Position> many_points;
@@ -136,6 +135,6 @@ TEST_CASE("Test BoundingBox")
     many_points.push_back(Position{i * 1e5, i * 1e5, i * 1e5});
   }
   BoundingBox many_points_box = BoundingBox::from_points(many_points);
-  REQUIRE(many_points_box.min_x == Catch::Approx(0.0));
-  REQUIRE(many_points_box.max_x == Catch::Approx(999e5));
+  REQUIRE(many_points_box.min_x == 0.0);
+  REQUIRE(many_points_box.max_x == 999e5);
 }

--- a/tests/test_bbox.cpp
+++ b/tests/test_bbox.cpp
@@ -73,9 +73,15 @@ TEST_CASE("Test BoundingBox")
   REQUIRE_FALSE(c.contains(outside));
 
   // Test max_chord_length() method
-  double max_chord = c.max_chord_length();
-  REQUIRE(max_chord > 0.0);
-  REQUIRE(max_chord < 1.0);
+  REQUIRE(a.max_chord_length() == Catch::Approx(std::sqrt(3.0)));
+  REQUIRE(b.max_chord_length() == Catch::Approx(std::sqrt(3.0)));
+  // box c at this point is 7x9x11
+  REQUIRE(c.max_chord_length() == Catch::Approx(std::sqrt(49.0 + 81.0 + 121.0)));
+
+  // Test dilation() method
+  REQUIRE(a.dilation() == Catch::Approx(std::sqrt(3.0) * std::pow(10, -std::numeric_limits<float>::digits10)));
+  REQUIRE(b.dilation() == Catch::Approx(std::sqrt(3.0) * std::pow(10, -std::numeric_limits<float>::digits10)));
+  REQUIRE(c.dilation() == Catch::Approx(std::sqrt(49.0 + 81.0 + 121.0) * std::pow(10, -std::numeric_limits<float>::digits10)));
 
   // Test from_points() static method
   std::vector<Position> points = {
@@ -107,9 +113,15 @@ TEST_CASE("Test BoundingBox")
   REQUIRE(small_box.center().x == Catch::Approx(1.5e-10));
 
   // Stress test with mixed positive/negative numbers
-  BoundingBox mixed_box{-1e10, 1e10, -1e10, 1e10, -1e10, 1e10};
+  BoundingBox mixed_box{-1e10, -1e10, -1e10, 1e10, 1e10, 1e10};
   REQUIRE(mixed_box.width().x == Catch::Approx(2e10));
   REQUIRE(mixed_box.center().x == Catch::Approx(0.0));
+  REQUIRE(mixed_box.min_x == -1e10);
+  REQUIRE(mixed_box.min_y == -1e10);
+  REQUIRE(mixed_box.min_z == -1e10);
+  REQUIRE(mixed_box.max_x == 1e10);
+  REQUIRE(mixed_box.max_y == 1e10);
+  REQUIRE(mixed_box.max_z == 1e10);
 
   // Stress test update() with extreme values
   BoundingBox stress_box;

--- a/tests/test_bbox.cpp
+++ b/tests/test_bbox.cpp
@@ -72,8 +72,8 @@ TEST_CASE("Test BoundingBox")
   REQUIRE(c.contains(inside));
   REQUIRE_FALSE(c.contains(outside));
 
-  // Test maximum_chord_length() method
-  double max_chord = c.maximum_chord_length();
+  // Test max_chord_length() method
+  double max_chord = c.max_chord_length();
   REQUIRE(max_chord > 0.0);
   REQUIRE(max_chord < 1.0);
 

--- a/tests/test_bbox.cpp
+++ b/tests/test_bbox.cpp
@@ -11,8 +11,12 @@
 
 using namespace xdg;
 
+
 TEST_CASE("Test BoundingBox")
 {
+
+  // set the precision for floating point number output to 15 decimal places
+  Catch::StringMaker<double>::precision = 15;
 
   BoundingBox a {0.0, 0.0, 0.0, 1.0, 1.0, 1.0};
 

--- a/tests/test_bbox.cpp
+++ b/tests/test_bbox.cpp
@@ -1,7 +1,10 @@
-
+#include <sstream>
 
 // testing includes
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/catch_approx.hpp>
 
 // xdg includes
 #include "xdg/bbox.h"
@@ -38,4 +41,89 @@ TEST_CASE("Test BoundingBox")
   REQUIRE(c.max_x == 5.0);
   REQUIRE(c.max_y == 6.0);
   REQUIRE(c.max_z == 7.0);
+
+  // Test center() method
+  Position center = c.center();
+  REQUIRE(center.x == Catch::Approx(1.5));
+  REQUIRE(center.y == Catch::Approx(1.5));
+  REQUIRE(center.z == Catch::Approx(1.5));
+
+  // Test width() method
+  Vec3da width = c.width();
+  REQUIRE(width.x == Catch::Approx(7.0));
+  REQUIRE(width.y == Catch::Approx(9.0));
+  REQUIRE(width.z == Catch::Approx(11.0));
+
+  // Test lower_left() method
+  Position lower = c.lower_left();
+  REQUIRE(lower.x == -2.0);
+  REQUIRE(lower.y == -3.0);
+  REQUIRE(lower.z == -4.0);
+
+  // Test upper_right() method
+  Position upper = c.upper_right();
+  REQUIRE(upper.x == 5.0);
+  REQUIRE(upper.y == 6.0);
+  REQUIRE(upper.z == 7.0);
+
+  // Test contains() method
+  Position inside {0.0, 0.0, 0.0};
+  Position outside {10.0, 10.0, 10.0};
+  REQUIRE(c.contains(inside));
+  REQUIRE_FALSE(c.contains(outside));
+
+  // Test maximum_chord_length() method
+  double max_chord = c.maximum_chord_length();
+  REQUIRE(max_chord > 0.0);
+  REQUIRE(max_chord < 1.0);
+
+  // Test from_points() static method
+  std::vector<Position> points = {
+    Position{1.0, 2.0, 3.0},
+    Position{4.0, 5.0, 6.0},
+    Position{-1.0, -2.0, -3.0}
+  };
+  BoundingBox from_points_box = BoundingBox::from_points(points);
+  REQUIRE(from_points_box.min_x == -1.0);
+  REQUIRE(from_points_box.min_y == -2.0);
+  REQUIRE(from_points_box.min_z == -3.0);
+  REQUIRE(from_points_box.max_x == 4.0);
+  REQUIRE(from_points_box.max_y == 5.0);
+  REQUIRE(from_points_box.max_z == 6.0);
+
+  // Test operator<<
+  std::stringstream ss;
+  ss << c;
+  CHECK_THAT(ss.str(), Catch::Matchers::Equals("Lower left: -2, -3, -4, Upper right: 5, 6, 7"));
+
+  // Stress test with large numbers
+  BoundingBox large_box{1e10, 1e10, 1e10, 2e10, 2e10, 2e10};
+  REQUIRE(large_box.width().x == Catch::Approx(1e10));
+  REQUIRE(large_box.center().x == Catch::Approx(1.5e10));
+
+  // Stress test with very small numbers
+  BoundingBox small_box{1e-10, 1e-10, 1e-10, 2e-10, 2e-10, 2e-10};
+  REQUIRE(small_box.width().x == Catch::Approx(1e-10));
+  REQUIRE(small_box.center().x == Catch::Approx(1.5e-10));
+
+  // Stress test with mixed positive/negative numbers
+  BoundingBox mixed_box{-1e10, 1e10, -1e10, 1e10, -1e10, 1e10};
+  REQUIRE(mixed_box.width().x == Catch::Approx(2e10));
+  REQUIRE(mixed_box.center().x == Catch::Approx(0.0));
+
+  // Stress test update() with extreme values
+  BoundingBox stress_box;
+  stress_box.update(Position{1e20, 1e20, 1e20});
+  stress_box.update(Position{-1e20, -1e20, -1e20});
+  REQUIRE(stress_box.width().x == Catch::Approx(2e20));
+  REQUIRE(stress_box.center().x == Catch::Approx(0.0));
+
+  // Stress test from_points() with many points
+  std::vector<Position> many_points;
+  for(int i = 0; i < 1000; i++) {
+    many_points.push_back(Position{i * 1e5, i * 1e5, i * 1e5});
+  }
+  BoundingBox many_points_box = BoundingBox::from_points(many_points);
+  REQUIRE(many_points_box.min_x == Catch::Approx(0.0));
+  REQUIRE(many_points_box.max_x == Catch::Approx(999e5));
 }


### PR DESCRIPTION
Adds some new methods and an `fmt` formatter to the `BoundingBox` class. Addditional tests have been included as well.

New methods:

  - width
  - center
  - lower_left (accessor)
  - upper_right (accessor)
  - max_chord_length (useful for setting box dilation)