### PR TITLE
Add tetrahedron containment methods

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,6 @@
 [submodule "vendor/--force"]
 	path = vendor/indicators
 	url = https://github.com/p-ranav/indicators
+[submodule "vendor/linalg"]
+	path = vendor/linalg
+	url = git@github.com:sgorsten/linalg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,12 @@ if (XDG_BUILD_TESTS)
   include(CTest)
 endif()
 
+
 # fmt
 find_package(fmt QUIET NO_SYSTEM_ENVIRONMENT_PATH)
 if (NOT fmt_FOUND)
-  set(FMT_INSTALL ON CACHE BOOL "Generate the fmt install target")
-  add_subdirectory(vendor/fmt)
+set(FMT_INSTALL ON CACHE BOOL "Generate the fmt install target")
+add_subdirectory(vendor/fmt)
 endif()
 
 # argparse
@@ -99,10 +100,10 @@ src/mesh_manager_interface.cpp
 src/ray_tracing_interface.cpp
 src/triangle_intersect.cpp
 src/util/str_utils.cpp
-src/xdg.cpp
+src/tetrahedron_contain.cpp
 src/overlap_check/overlap.cpp
+src/xdg.cpp
 )
-
 
 if (XDG_ENABLE_EMBREE)
 list(APPEND xdg_sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,8 +80,10 @@ endif()
 # fmt
 find_package(fmt QUIET NO_SYSTEM_ENVIRONMENT_PATH)
 if (NOT fmt_FOUND)
-set(FMT_INSTALL ON CACHE BOOL "Generate the fmt install target")
-add_subdirectory(vendor/fmt)
+  set(FMT_INSTALL ON CACHE BOOL "Generate the fmt install target")
+  add_subdirectory(vendor/fmt)
+else()
+  message(STATUS "Found fmt ${fmt_VERSION} at ${fmt_DIR}")
 endif()
 
 # argparse

--- a/include/xdg/constants.h
+++ b/include/xdg/constants.h
@@ -22,6 +22,9 @@ constexpr double INFTY {std::numeric_limits<double>::max()};
 
 constexpr double DILATION_FACTOR {std::pow(10, -std::numeric_limits<float>::digits10)};
 
+// TODO : Consider this as an option for managing missed hits?
+constexpr double PLUCKER_TOL {10 * std::numeric_limits<double>::epsilon()};
+
 // Whether information pertains to a surface or volume
 enum class GeometryType {
  SURFACE = 2,

--- a/include/xdg/geometry/plucker.h
+++ b/include/xdg/geometry/plucker.h
@@ -5,6 +5,21 @@
 
 namespace xdg {
 
+
+/*
+ * Triangle vertex ordering convention:
+ *
+ *      v2
+ *     /  \
+ *    /    \
+ *   /      \
+ *  /        \
+ * v0--------v1
+ *
+ * The vertices are ordered counter-clockwise when viewed from the front face
+ * (normal pointing out of the plane). This ordering is based on the reference:
+ * https://doi.org/10.1002/cnm.1237
+ */
 bool plucker_ray_tri_intersect(const std::array<Position, 3> vertices,
                                const Position& origin,
                                const Direction& direction,

--- a/include/xdg/tetrahedron_contain.h
+++ b/include/xdg/tetrahedron_contain.h
@@ -43,10 +43,6 @@ bool plucker_tet_containment_test(const Position& point,
   const Position& v2,
   const Position& v3);
 
-void VolumeElementBoundsFunc(RTCBoundsFunctionArguments* args);
-void TetrahedronIntersectionFunc(RTCIntersectFunctionNArguments* args);
-void TetrahedronOcclusionFunc(RTCOccludedFunctionNArguments* args);
-
 } // namespace xdg
 
 #endif // include guard

--- a/include/xdg/tetrahedron_contain.h
+++ b/include/xdg/tetrahedron_contain.h
@@ -8,40 +8,34 @@ namespace xdg
 {
 
 /**
- * @brief Computes the side of a point relative to a triangle face.
+ * @brief Determines if a point is inside or on the boundary of a tetrahedron
+ * using Plücker coordinates.
  *
- * The signed volume is calculated using the scalar triple product of vectors formed
- * by the input positions. A positive volume indicates a specific orientation of the
- * tetrahedron, while a negative volume indicates the opposite orientation.
+ * This function performs a containment test for a point relative to a
+ * tetrahedron defined by four vertices. The ordering of these vertices is based
+ * on the following reference: https://doi.org/10.1002/cnm.1237 where each
+ * triangle is oriented counter-clockwise when viewed from the front face
+ * (normals pointing outward with respect to the tetrahedron). It uses
+ * barycentric coordinates to determine whether the point lies inside, on the
  *
- * @param point The query location.
- * @param v0 The first vertex of the triangle face.
- * @param v1 The second vertex of the triangle face.
- * @param v2 The third vertex of the triangle face.
- * @return The signed volume of the triangle face.
- */
-double face_side_test(const Position& point, const Position& v0, const Position& v1, const Position& v2);
-
-
-/**
- * @brief Determines if a point is inside or on the boundary of a tetrahedron using Plücker coordinates.
- *
- * This function performs a containment test for a point relative to a tetrahedron defined by four vertices.
- * It uses signed volume tests (via `face_side_test`) to determine whether the point lies inside, on the boundary,
- * or outside the tetrahedron. If the point lies exactly on a face of the tetrahedron, it is considered inside.
+ * It uses signed
+ * volume tests (via `face_side_test`) to determine whether the point lies
+ * inside, on the boundary, or outside the tetrahedron. If the point lies
+ * exactly on a face of the tetrahedron, it is considered inside.
  *
  * @param point The position of the point to test.
  * @param v0 The position of the first vertex of the tetrahedron.
  * @param v1 The position of the second vertex of the tetrahedron.
  * @param v2 The position of the third vertex of the tetrahedron.
  * @param v3 The position of the fourth vertex of the tetrahedron.
- * @return `true` if the point is inside or on the boundary of the tetrahedron, `false` otherwise.
+ * @return `true` if the point is inside or on the boundary of the tetrahedron,
+ * `false` otherwise.
  */
 bool plucker_tet_containment_test(const Position& point,
-  const Position& v0,
-  const Position& v1,
-  const Position& v2,
-  const Position& v3);
+                                  const Vertex& v0,
+                                  const Vertex& v1,
+                                  const Vertex& v2,
+                                  const Vertex& v3);
 
 } // namespace xdg
 

--- a/include/xdg/tetrahedron_contain.h
+++ b/include/xdg/tetrahedron_contain.h
@@ -1,0 +1,52 @@
+#ifndef XDG_TETRAHEDRON_INTERSECT_H
+#define XDG_TETRAHEDRON_INTERSECT_H
+
+
+#include "xdg/vec3da.h"
+
+namespace xdg
+{
+
+/**
+ * @brief Computes the side of a point relative to a triangle face.
+ *
+ * The signed volume is calculated using the scalar triple product of vectors formed
+ * by the input positions. A positive volume indicates a specific orientation of the
+ * tetrahedron, while a negative volume indicates the opposite orientation.
+ *
+ * @param point The query location.
+ * @param v0 The first vertex of the triangle face.
+ * @param v1 The second vertex of the triangle face.
+ * @param v2 The third vertex of the triangle face.
+ * @return The signed volume of the triangle face.
+ */
+double face_side_test(const Position& point, const Position& v0, const Position& v1, const Position& v2);
+
+
+/**
+ * @brief Determines if a point is inside or on the boundary of a tetrahedron using Plücker coordinates.
+ *
+ * This function performs a containment test for a point relative to a tetrahedron defined by four vertices.
+ * It uses signed volume tests (via `face_side_test`) to determine whether the point lies inside, on the boundary,
+ * or outside the tetrahedron. If the point lies exactly on a face of the tetrahedron, it is considered inside.
+ *
+ * @param point The position of the point to test.
+ * @param v0 The position of the first vertex of the tetrahedron.
+ * @param v1 The position of the second vertex of the tetrahedron.
+ * @param v2 The position of the third vertex of the tetrahedron.
+ * @param v3 The position of the fourth vertex of the tetrahedron.
+ * @return `true` if the point is inside or on the boundary of the tetrahedron, `false` otherwise.
+ */
+bool plucker_tet_containment_test(const Position& point,
+  const Position& v0,
+  const Position& v1,
+  const Position& v2,
+  const Position& v3);
+
+void VolumeElementBoundsFunc(RTCBoundsFunctionArguments* args);
+void TetrahedronIntersectionFunc(RTCIntersectFunctionNArguments* args);
+void TetrahedronOcclusionFunc(RTCOccludedFunctionNArguments* args);
+
+} // namespace xdg
+
+#endif // include guard

--- a/include/xdg/util/linalg.h
+++ b/include/xdg/util/linalg.h
@@ -1,0 +1,1 @@
+../../../vendor/linalg/linalg.h

--- a/src/tetrahedron_contain.cpp
+++ b/src/tetrahedron_contain.cpp
@@ -1,0 +1,57 @@
+#include "xdg/constants.h"
+#include "xdg/ray_tracing_interface.h"
+#include "xdg/ray.h"
+#include "xdg/vec3da.h"
+
+#include "xdg/util/linalg.h"
+
+namespace xdg
+{
+
+double face_side_test(const Position& point, const Position& v0, const Position& v1, const Position& v2) {
+  // Compute the face normal using the cross product of two edge vectors
+  auto face_normal = cross(v1 - v0, v2 - v0).normalize();
+
+  auto vec_a = v0 - point;
+  auto vec_b = v1 - point;
+  auto vec_c = v2 - point;
+
+  auto cross_product = cross(vec_a, vec_b).normalize();
+  return dot(cross_product, vec_c);
+}
+
+bool plucker_tet_containment_test(const Position& point,
+                                  const Position& v0,
+                                  const Position& v1,
+                                  const Position& v2,
+                                  const Position& v3) {
+    using namespace linalg::aliases;
+    // Create matrix T = [v1 - v0, v2 - v0, v3 - v0]
+    Vec3da e0 = v1 - v0;
+    Vec3da e1 = v2 - v0;
+    Vec3da e2 = v3 - v0;
+    double3x3 T = { {e0.x, e0.y, e0.z},
+                   {e1.x, e1.y, e1.z},
+                   {e2.x, e2.y, e2.z}};
+
+    // Vector from v0 to point
+    Vec3da rhs = point - v0;
+
+    // Solve T * [λ1, λ2, λ3] = rhs
+    double3 lambda123 = mul(inverse(T),{rhs.x, rhs.y, rhs.z});
+
+    // Compute λ0
+    double lambda0 = 1.0f - (lambda123.x + lambda123.y + lambda123.z);
+
+    // Final barycentric coordinate vector
+    double4 bary = { lambda0, lambda123.x, lambda123.y, lambda123.z };
+
+    // Check all λ_i in [0, 1]
+    for (int i = 0; i < 4; ++i) {
+        if (bary[i] < -PLUCKER_TOL || bary[i] > 1.0f + PLUCKER_TOL)
+            return false;
+    }
+    return true;
+}
+
+} // namespace xdg

--- a/src/tetrahedron_contain.cpp
+++ b/src/tetrahedron_contain.cpp
@@ -8,18 +8,6 @@
 namespace xdg
 {
 
-double face_side_test(const Position& point, const Position& v0, const Position& v1, const Position& v2) {
-  // Compute the face normal using the cross product of two edge vectors
-  auto face_normal = cross(v1 - v0, v2 - v0).normalize();
-
-  auto vec_a = v0 - point;
-  auto vec_b = v1 - point;
-  auto vec_c = v2 - point;
-
-  auto cross_product = cross(vec_a, vec_b).normalize();
-  return dot(cross_product, vec_c);
-}
-
 bool plucker_tet_containment_test(const Position& point,
                                   const Position& v0,
                                   const Position& v1,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ test_point_in_volume
 test_normal
 test_measure
 test_xdg_interface
+test_tet_containment
 )
 
 if (XDG_ENABLE_MOAB)

--- a/tests/test_tet_containment.cpp
+++ b/tests/test_tet_containment.cpp
@@ -25,11 +25,44 @@ TEST_CASE("Tetrahedron Intersection Unit Test")
   Position boundary_point(0.0, 0.0, 0.5); // On a face
 
   // Check containment
-  REQUIRE(plucker_tet_containment_test(inside_point, v0, v1, v2, v3) == true);
-  REQUIRE(plucker_tet_containment_test(outside_point, v0, v1, v2, v3) == false);
-  REQUIRE(plucker_tet_containment_test(boundary_point, v0, v1, v2, v3) == true);
+  CHECK(plucker_tet_containment_test(inside_point, v0, v1, v2, v3) == true);
+  CHECK(plucker_tet_containment_test(outside_point, v0, v1, v2, v3) == false);
+  CHECK(plucker_tet_containment_test(boundary_point, v0, v1, v2, v3) == true);
 
   // Check point that is co-planar with one of the faces, but outside the tet
   Position coplanar_exterior_point(-0.5, -0.5, 0.0);
-  REQUIRE(plucker_tet_containment_test(coplanar_exterior_point, v0, v1, v2, v3) == false);
+  CHECK(plucker_tet_containment_test(coplanar_exterior_point, v0, v1, v2, v3) == false);
+
+  // Test points near the faces but not coplanar
+  Position near_face012(0.3, 0.3, 0.1);
+  Position near_face013(0.3, 0.1, 0.3);
+  Position near_face023(0.1, 0.3, 0.3);
+  Position near_face123(0.3, 0.3, 0.3);
+
+  CHECK(plucker_tet_containment_test(near_face012, v0, v1, v2, v3) == true);
+  CHECK(plucker_tet_containment_test(near_face013, v0, v1, v2, v3) == true);
+  CHECK(plucker_tet_containment_test(near_face023, v0, v1, v2, v3) == true);
+  CHECK(plucker_tet_containment_test(near_face123, v0, v1, v2, v3) == true);
+
+  // Test points just outside the tetrahedron
+  Position just_outside_face012(0.3, 0.3, -0.1);
+  Position just_outside_face013(0.3, -0.1, 0.3);
+  Position just_outside_face023(-0.1, 0.3, 0.3);
+  Position just_outside_face123(0.4, 0.4, 0.4);
+
+  CHECK(plucker_tet_containment_test(just_outside_face012, v0, v1, v2, v3) == false);
+  CHECK(plucker_tet_containment_test(just_outside_face013, v0, v1, v2, v3) == false);
+  CHECK(plucker_tet_containment_test(just_outside_face023, v0, v1, v2, v3) == false);
+  CHECK(plucker_tet_containment_test(just_outside_face123, v0, v1, v2, v3) == false);
+
+  // Test points just inside the tetrahedron
+  Position just_inside_face012(0.3, 0.3, 0.1);
+  Position just_inside_face013(0.3, 0.1, 0.3);
+  Position just_inside_face023(0.1, 0.3, 0.3);
+  Position just_inside_face123(0.3, 0.3, 0.3);
+
+  CHECK(plucker_tet_containment_test(just_inside_face012, v0, v1, v2, v3) == true);
+  CHECK(plucker_tet_containment_test(just_inside_face013, v0, v1, v2, v3) == true);
+  CHECK(plucker_tet_containment_test(just_inside_face023, v0, v1, v2, v3) == true);
+  CHECK(plucker_tet_containment_test(just_inside_face123, v0, v1, v2, v3) == true);
 }

--- a/tests/test_tet_containment.cpp
+++ b/tests/test_tet_containment.cpp
@@ -65,4 +65,31 @@ TEST_CASE("Tetrahedron Intersection Unit Test")
   CHECK(plucker_tet_containment_test(just_inside_face013, v0, v1, v2, v3) == true);
   CHECK(plucker_tet_containment_test(just_inside_face023, v0, v1, v2, v3) == true);
   CHECK(plucker_tet_containment_test(just_inside_face123, v0, v1, v2, v3) == true);
+
+  // Create a second tetrahedron with different orientation
+  Position v0_2(1.0, 1.0, 1.0);
+  Position v1_2(2.0, 1.0, 1.0);
+  Position v2_2(1.0, 2.0, 1.0);
+  Position v3_2(1.0, 1.0, 2.0);
+
+  // Test points for second tetrahedron
+  Position inside_point_2(1.2, 1.2, 1.2);
+  Position outside_point_2(0.0, 0.0, 0.0);
+  Position boundary_point_2(1.0, 1.0, 1.5);
+
+  // Check containment for second tetrahedron
+  CHECK(plucker_tet_containment_test(inside_point_2, v0_2, v1_2, v2_2, v3_2) == true);
+  CHECK(plucker_tet_containment_test(outside_point_2, v0_2, v1_2, v2_2, v3_2) == false);
+  CHECK(plucker_tet_containment_test(boundary_point_2, v0_2, v1_2, v2_2, v3_2) == true);
+
+  // Test points near faces of second tetrahedron
+  Position near_face_2(1.3, 1.3, 1.1);
+  Position just_outside_face_2(1.3, 1.3, 0.9);
+
+  CHECK(plucker_tet_containment_test(near_face_2, v0_2, v1_2, v2_2, v3_2) == true);
+  CHECK(plucker_tet_containment_test(just_outside_face_2, v0_2, v1_2, v2_2, v3_2) == false);
+
+  // Test points that are in one tet but not the other
+  CHECK(plucker_tet_containment_test(inside_point, v0_2, v1_2, v2_2, v3_2) == false);
+  CHECK(plucker_tet_containment_test(inside_point_2, v0, v1, v2, v3) == false);
 }

--- a/tests/test_tet_containment.cpp
+++ b/tests/test_tet_containment.cpp
@@ -1,0 +1,35 @@
+// stl includes
+#include <memory>
+
+// testing includes
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include "xdg/ray_tracing_interface.h"
+#include "xdg/tetrahedron_contain.h"
+#include "xdg/vec3da.h"
+
+using namespace xdg;
+
+TEST_CASE("Tetrahedron Intersection Unit Test")
+{
+  // Define tetrahedron vertices
+  Position v0(0.0, 0.0, 0.0);
+  Position v1(1.0, 0.0, 0.0);
+  Position v2(0.0, 1.0, 0.0);
+  Position v3(0.0, 0.0, 1.0);
+
+  // Test points
+  Position inside_point(0.1, 0.1, 0.1); // Inside the tetrahedron
+  Position outside_point(2.0, 2.0, 2.0); // Clearly outside
+  Position boundary_point(0.0, 0.0, 0.5); // On a face
+
+  // Check containment
+  REQUIRE(plucker_tet_containment_test(inside_point, v0, v1, v2, v3) == true);
+  REQUIRE(plucker_tet_containment_test(outside_point, v0, v1, v2, v3) == false);
+  REQUIRE(plucker_tet_containment_test(boundary_point, v0, v1, v2, v3) == true);
+
+  // Check point that is co-planar with one of the faces, but outside the tet
+  Position coplanar_exterior_point(-0.5, -0.5, 0.0);
+  REQUIRE(plucker_tet_containment_test(coplanar_exterior_point, v0, v1, v2, v3) == false);
+}


### PR DESCRIPTION
This adds point containment checks for linear tets using barycentric coordinates. The matrices for computing these coordinates are supported by the header-only [linalg](https://github.com/sgorsten/linalg) library. Associated tests are included.