### PR TITLE
Faster/simpler sidepair IDs for libMesh

### DIFF
--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -248,9 +248,6 @@ public:
     if (sidepair_to_mesh_id_.count(sidepair) == 0) {
       MeshID id = next_sidepair_id();
       mesh_id_to_sidepair_[id] = sidepair;
-      if (sidepair_to_mesh_id_.count(sidepair) > 0) {
-        fatal_error("SidePair already exists in sidepair_to_mesh_id_");
-      }
       sidepair_to_mesh_id_[sidepair] = id;
       return id;
     } else {

--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -266,11 +266,8 @@ public:
     return mesh_id_to_sidepair_.at(sidepair);
   }
 
-  MeshID next_sidepair_id() const {
-    if (mesh_id_to_sidepair_.size() == 0) {
-      return 1;
-    }
-    return std::max_element(mesh_id_to_sidepair_.begin(), mesh_id_to_sidepair_.end())->first + 1;
+  MeshID next_sidepair_id() {
+    return next_sidepair_id_++;
   }
 
   struct MeshIDPairHash {
@@ -311,6 +308,8 @@ public:
   //! Mapping of surfaces to the volumes on either side. Volumes are ordered
   //! based on their sense with respect to the surface triangles
   std::unordered_map<MeshID, std::pair<MeshID, MeshID>> surface_senses_;
+
+  int32_t next_sidepair_id_ {1}; //!< Next available sidepair ID, starts at one
 };
 
 } // namespace xdg


### PR DESCRIPTION
In setting up larger models with libMesh I found that, unsurprisingly, a ton of time was spent in `std::max_element` figuring out what the next available sidepair ID was. 

This replaces that approach by simply incrementing an internal ID value. It's not very sophisticated, but it's efficient.