### PR TITLE
Use face adjacencies to enter element from implicit complement

### DIFF
--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -102,6 +102,8 @@ public:
 
   std::vector<MeshID> face_connectivity(MeshID element) const override;
 
+  std::vector<MeshID> get_face_elements(MeshID face) const override;
+
   Vertex vertex_coordinates(MeshID vertex) const override;
 
   std::array<Vertex, 3> face_vertices(MeshID triangle) const override;

--- a/include/xdg/libmesh/mesh_manager.h
+++ b/include/xdg/libmesh/mesh_manager.h
@@ -102,7 +102,7 @@ public:
 
   std::vector<MeshID> face_connectivity(MeshID element) const override;
 
-  std::vector<MeshID> get_face_elements(MeshID face) const override;
+  MeshID get_boundary_face_element(MeshID face) const override;
 
   Vertex vertex_coordinates(MeshID vertex) const override;
 

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -150,11 +150,11 @@ public:
   virtual
   std::vector<MeshID> face_connectivity(MeshID face) const = 0;
 
-  //! \brief Get the volume element IDs adjacent to a face
+  //! \brief Get a face's owning element for boundary-face use cases
   //! \param face The face ID
-  //! \return A vector containing the adjacent element IDs
+  //! \return The owning element ID, or ID_NONE if no boundary owner is available
   virtual
-  std::vector<MeshID> get_face_elements(MeshID face) const = 0;
+  MeshID get_boundary_face_element(MeshID face) const = 0;
 
   BoundingBox element_bounding_box(MeshID element) const;
 

--- a/include/xdg/mesh_manager_interface.h
+++ b/include/xdg/mesh_manager_interface.h
@@ -150,6 +150,12 @@ public:
   virtual
   std::vector<MeshID> face_connectivity(MeshID face) const = 0;
 
+  //! \brief Get the volume element IDs adjacent to a face
+  //! \param face The face ID
+  //! \return A vector containing the adjacent element IDs
+  virtual
+  std::vector<MeshID> get_face_elements(MeshID face) const = 0;
+
   BoundingBox element_bounding_box(MeshID element) const;
 
   BoundingBox face_bounding_box(MeshID element) const;

--- a/include/xdg/moab/direct_access.h
+++ b/include/xdg/moab/direct_access.h
@@ -135,7 +135,7 @@ private:
           std::vector<EntityHandle> verts;
           for (auto idx : o) verts.push_back(conn[idx]);
           Range adj_ents;
-          rval = mbi->get_adjacencies(verts.data(), verts.size(), 3, true, adj_ents);
+          rval = mbi->get_adjacencies(verts.data(), verts.size(), 3, false, adj_ents);
 
           // there be at most two adjacent elements for a given face
           if (adj_ents.size() > 2) {

--- a/include/xdg/moab/direct_access.h
+++ b/include/xdg/moab/direct_access.h
@@ -91,6 +91,10 @@ public:
     return element_adjacency_data_.get_element_adjacencies(element);
   }
 
+  inline EntityHandle get_boundary_face_element(const EntityHandle& face) const {
+    return boundary_face_adjacency_data_.get_boundary_face_element(face);
+  }
+
   const std::vector<std::vector<int>>& get_face_ordering(EntityType entity_type) const {
     return element_adjacency_data_.ordering.at(entity_type);
   }
@@ -217,7 +221,7 @@ private:
 
     template <int N>
     std::array<size_t, N>
-    get_connectivity_indices(const EntityHandle& e) {
+    get_connectivity_indices(const EntityHandle& e) const {
       // determine the correct contiguous block index to use
       int block_idx = 0;
       auto fe = first_elements[block_idx];
@@ -241,6 +245,43 @@ private:
       first_elements.clear();
       vconn.clear();
       entity_range.clear();
+    }
+  };
+
+  struct BoundaryFaceAdjacencyData {
+    std::unordered_map<EntityHandle, EntityHandle> boundary_face_to_element_;
+
+    void setup(Interface* mbi, const ConnectivityData& face_data) {
+      ErrorCode rval;
+
+      for (const auto& face : face_data.entity_range) {
+        auto conn = face_data.get_connectivity_indices<3>(face);
+        std::array<EntityHandle, 3> verts = {conn[0], conn[1], conn[2]};
+
+        Range adjacent_elements;
+        rval = mbi->get_adjacencies(verts.data(), verts.size(), 3, true, adjacent_elements);
+        MB_CHK_SET_ERR_CONT(rval, "Failed to get MOAB boundary face adjacencies");
+
+        if (adjacent_elements.size() > 2) {
+          throw std::runtime_error("Found more than two elements adjacent to a face");
+        }
+
+        if (adjacent_elements.size() == 1) {
+          boundary_face_to_element_[face] = adjacent_elements[0];
+        }
+      }
+    }
+
+    EntityHandle get_boundary_face_element(const EntityHandle& face) const {
+      auto it = boundary_face_to_element_.find(face);
+      if (it == boundary_face_to_element_.end()) {
+        return xdg::ID_NONE;
+      }
+      return it->second;
+    }
+
+    void clear() {
+      boundary_face_to_element_.clear();
     }
   };
 
@@ -310,6 +351,7 @@ private:
   ConnectivityData face_data_;
   ConnectivityData element_data_;
   AdjacencyData element_adjacency_data_;
+  BoundaryFaceAdjacencyData boundary_face_adjacency_data_;
   VertexData vertex_data_;
 
   public:

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -72,6 +72,8 @@ public:
 
   std::vector<MeshID> face_connectivity(MeshID face) const override;
 
+  std::vector<MeshID> get_face_elements(MeshID face) const override;
+
   Vertex vertex_coordinates(MeshID vertex) const override;
 
   std::vector<Vertex> element_vertices(MeshID element) const override;

--- a/include/xdg/moab/mesh_manager.h
+++ b/include/xdg/moab/mesh_manager.h
@@ -72,7 +72,7 @@ public:
 
   std::vector<MeshID> face_connectivity(MeshID face) const override;
 
-  std::vector<MeshID> get_face_elements(MeshID face) const override;
+  MeshID get_boundary_face_element(MeshID face) const override;
 
   Vertex vertex_coordinates(MeshID vertex) const override;
 

--- a/src/libmesh/mesh_manager.cpp
+++ b/src/libmesh/mesh_manager.cpp
@@ -137,19 +137,13 @@ LibMeshManager::face_connectivity(MeshID face) const {
   return conn;
 }
 
-std::vector<MeshID>
-LibMeshManager::get_face_elements(MeshID face) const {
+MeshID
+LibMeshManager::get_boundary_face_element(MeshID face) const {
   const auto& sp = sidepair(face);
-
-  std::vector<MeshID> elements;
-  elements.reserve(2);
   if (sp.first()) {
-    elements.push_back(sp.first()->id());
+    return sp.first()->id();
   }
-  if (sp.second()) {
-    elements.push_back(sp.second()->id());
-  }
-  return elements;
+  return ID_NONE;
 }
 
 MeshID LibMeshManager::create_volume() {

--- a/src/libmesh/mesh_manager.cpp
+++ b/src/libmesh/mesh_manager.cpp
@@ -137,6 +137,21 @@ LibMeshManager::face_connectivity(MeshID face) const {
   return conn;
 }
 
+std::vector<MeshID>
+LibMeshManager::get_face_elements(MeshID face) const {
+  const auto& sp = sidepair(face);
+
+  std::vector<MeshID> elements;
+  elements.reserve(2);
+  if (sp.first()) {
+    elements.push_back(sp.first()->id());
+  }
+  if (sp.second()) {
+    elements.push_back(sp.second()->id());
+  }
+  return elements;
+}
+
 MeshID LibMeshManager::create_volume() {
   MeshID next_volume_id = *std::max_element(volumes_.begin(), volumes_.end()) + 1;
   return next_volume_id;

--- a/src/moab/direct_access.cpp
+++ b/src/moab/direct_access.cpp
@@ -21,6 +21,7 @@ MBDirectAccess::setup() {
   element_data_.setup(mbi);
   vertex_data_.setup(mbi);
   element_adjacency_data_.setup(mbi);
+  boundary_face_adjacency_data_.setup(mbi, face_data_);
 }
 
 void
@@ -30,6 +31,7 @@ MBDirectAccess::clear()
   element_data_.clear();
   vertex_data_.clear();
   element_adjacency_data_.clear();
+  boundary_face_adjacency_data_.clear();
 }
 
 void

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -462,20 +462,18 @@ MOABMeshManager::face_connectivity(MeshID face) const
   return this->mb_direct()->get_face_connectivity(face_handle);
 }
 
-std::vector<MeshID>
-MOABMeshManager::get_face_elements(MeshID face) const
+MeshID
+MOABMeshManager::get_boundary_face_element(MeshID face) const
 {
   moab::EntityHandle face_handle;
   this->moab_interface()->handle_from_id(moab::MBTRI, face, face_handle);
 
   moab::EntityHandle element_handle = this->mb_direct()->get_boundary_face_element(face_handle);
   if (element_handle == ID_NONE) {
-    return {};
+    return ID_NONE;
   }
 
-  std::vector<MeshID> element_ids;
-  element_ids.push_back(this->moab_interface()->id_from_handle(element_handle));
-  return element_ids;
+  return this->moab_interface()->id_from_handle(element_handle);
 }
 
 double

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -468,17 +468,13 @@ MOABMeshManager::get_face_elements(MeshID face) const
   moab::EntityHandle face_handle;
   this->moab_interface()->handle_from_id(moab::MBTRI, face, face_handle);
 
-  std::vector<moab::EntityHandle> face_vertices;
-  this->moab_interface()->get_connectivity(&face_handle, 1, face_vertices);
-
-  moab::Range adjacent_elements;
-  this->moab_interface()->get_adjacencies(face_vertices.data(), face_vertices.size(), 3, true, adjacent_elements);
+  moab::EntityHandle element_handle = this->mb_direct()->get_boundary_face_element(face_handle);
+  if (element_handle == ID_NONE) {
+    return {};
+  }
 
   std::vector<MeshID> element_ids;
-  element_ids.reserve(adjacent_elements.size());
-  for (const auto& element : adjacent_elements) {
-    element_ids.push_back(this->moab_interface()->id_from_handle(element));
-  }
+  element_ids.push_back(this->moab_interface()->id_from_handle(element_handle));
   return element_ids;
 }
 

--- a/src/moab/mesh_manager.cpp
+++ b/src/moab/mesh_manager.cpp
@@ -462,6 +462,26 @@ MOABMeshManager::face_connectivity(MeshID face) const
   return this->mb_direct()->get_face_connectivity(face_handle);
 }
 
+std::vector<MeshID>
+MOABMeshManager::get_face_elements(MeshID face) const
+{
+  moab::EntityHandle face_handle;
+  this->moab_interface()->handle_from_id(moab::MBTRI, face, face_handle);
+
+  std::vector<moab::EntityHandle> face_vertices;
+  this->moab_interface()->get_connectivity(&face_handle, 1, face_vertices);
+
+  moab::Range adjacent_elements;
+  this->moab_interface()->get_adjacencies(face_vertices.data(), face_vertices.size(), 3, true, adjacent_elements);
+
+  std::vector<MeshID> element_ids;
+  element_ids.reserve(adjacent_elements.size());
+  for (const auto& element : adjacent_elements) {
+    element_ids.push_back(this->moab_interface()->id_from_handle(element));
+  }
+  return element_ids;
+}
+
 double
 MOABMeshManager::element_volume(MeshID element) const
 {

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -188,16 +188,12 @@ XDG::segments(const Position& start,
       // }
 
       // Get the element on the other side of the hit face using adjacencies
-      auto adjacent_element = mesh_manager()->get_face_elements(exclude_primitives.back());
-      if (adjacent_element.size() == 0) {
+      auto adjacent_element = mesh_manager()->get_boundary_face_element(exclude_primitives.back());
+      if (adjacent_element == ID_NONE) {
         warning("Ray fire hit surface {}, but no adjacent elements were found on the other side of the surface.", hit.second);
         return segments;
       }
-      if (adjacent_element.size() > 1) {
-        warning("Ray fire hit surface {}, but multiple adjacent elements were found on the other side of the surface. This likely indicates a problem with the mesh connectivity.", hit.second);
-        return segments;
-      }
-      current_element = adjacent_element[0];
+      current_element = adjacent_element;
       exclude_primitives.clear();
     }
     auto vol_segments = mesh_manager()->walk_elements(current_element, r, u, distance);

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -163,19 +163,15 @@ XDG::segments(const Position& start,
     MeshID volume = ID_NONE;
     if (current_element == ID_NONE) {
       // fire a ray against the implicit complement
-      auto hit = ray_fire(ipc, r, u, INFTY, HitOrientation::ANY, &prev_elements);
-      // if the hit distance is zero, we're likely stuck on an element boundary
-      // fire again and ignore the previous hit
-      while (hit.first < TINY_BIT) {
-        hit = ray_fire(ipc, r, u, INFTY, HitOrientation::ANY, &prev_elements);
-      }
+      auto hit = ray_fire(ipc, r + u * TINY_BIT, u, INFTY, HitOrientation::EXITING, &exclude_primitives);
       // if there is no entry point or the distance to the surface
       // is past the end point, return
       if (hit.second == ID_NONE || hit.first > distance) return segments;
 
+      double hit_dist = hit.first + TINY_BIT;
       // move up to the surface
-      r += u * hit.first;
-      distance -= hit.first;
+      r += u * hit_dist;
+      distance -= hit_dist;
       // determine the volume we're moving into
       mesh_manager()->next_volume(ipc, hit.second);
 

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -152,7 +152,7 @@ XDG::segments(const Position& start,
   double distance = u.length();
   u /= distance;
 
-  std::vector<xdg::MeshID> exclude_primitives;
+  std::vector<xdg::MeshID> hit_primitives;
 
   std::vector<std::pair<MeshID, double>> segments;
   while (distance > 0) {
@@ -163,7 +163,7 @@ XDG::segments(const Position& start,
     MeshID volume = ID_NONE;
     if (current_element == ID_NONE) {
       // fire a ray against the implicit complement
-      auto hit = ray_fire(ipc, r + u * TINY_BIT, u, INFTY, HitOrientation::EXITING, &exclude_primitives);
+      auto hit = ray_fire(ipc, r + u * TINY_BIT, u, INFTY, HitOrientation::EXITING, &hit_primitives);
       // if there is no entry point or the distance to the surface
       // is past the end point, return
       if (hit.second == ID_NONE || hit.first > distance) return segments;
@@ -175,22 +175,14 @@ XDG::segments(const Position& start,
       // determine the volume we're moving into
       mesh_manager()->next_volume(ipc, hit.second);
 
-      // // determine what element is on the other side of this surface
-      // current_element = find_element(r + u * TINY_BIT);
-
-      // if (current_element == ID_NONE) {
-      //   // warning("Ray fire hit surface {}, but could not find element on the other side of the surface.", hit.second);
-      //   return segments;
-      // }
-
       // Get the element on the other side of the hit face using adjacencies
-      auto adjacent_element = mesh_manager()->get_boundary_face_element(exclude_primitives.back());
+      auto adjacent_element = mesh_manager()->get_boundary_face_element(hit_primitives.back());
       if (adjacent_element == ID_NONE) {
         warning("Ray fire hit surface {}, but no adjacent elements were found on the other side of the surface.", hit.second);
         return segments;
       }
       current_element = adjacent_element;
-      exclude_primitives.clear();
+      hit_primitives.clear();
     }
     auto vol_segments = mesh_manager()->walk_elements(current_element, r, u, distance);
     // add to current set of segments

--- a/src/xdg.cpp
+++ b/src/xdg.cpp
@@ -152,6 +152,8 @@ XDG::segments(const Position& start,
   double distance = u.length();
   u /= distance;
 
+  std::vector<xdg::MeshID> exclude_primitives;
+
   std::vector<std::pair<MeshID, double>> segments;
   while (distance > 0) {
     // attempt to find an element at the start location
@@ -177,13 +179,26 @@ XDG::segments(const Position& start,
       // determine the volume we're moving into
       mesh_manager()->next_volume(ipc, hit.second);
 
-      // determine what element is on the other side of this surface
-      current_element = find_element(r + u * TINY_BIT);
-      // if no element is found, we may be exiting the mesh
-      if (current_element == ID_NONE) {
+      // // determine what element is on the other side of this surface
+      // current_element = find_element(r + u * TINY_BIT);
+
+      // if (current_element == ID_NONE) {
+      //   // warning("Ray fire hit surface {}, but could not find element on the other side of the surface.", hit.second);
+      //   return segments;
+      // }
+
+      // Get the element on the other side of the hit face using adjacencies
+      auto adjacent_element = mesh_manager()->get_face_elements(exclude_primitives.back());
+      if (adjacent_element.size() == 0) {
+        warning("Ray fire hit surface {}, but no adjacent elements were found on the other side of the surface.", hit.second);
         return segments;
       }
-      prev_elements.clear();
+      if (adjacent_element.size() > 1) {
+        warning("Ray fire hit surface {}, but multiple adjacent elements were found on the other side of the surface. This likely indicates a problem with the mesh connectivity.", hit.second);
+        return segments;
+      }
+      current_element = adjacent_element[0];
+      exclude_primitives.clear();
     }
     auto vol_segments = mesh_manager()->walk_elements(current_element, r, u, distance);
     // add to current set of segments

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,8 @@ pincell.h5m
 pincell-implicit.exo
 small-tet-mesh.h5m
 small-tet-mesh.exo
+single-tet.h5m
+single-tet.exo
 )
 
 foreach(file ${TEST_FILES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(
 TEST_NAMES
 test_bbox
+test_boundary_faces
 test_bvh
 test_config
 test_closest

--- a/tests/mesh_mock.h
+++ b/tests/mesh_mock.h
@@ -218,10 +218,9 @@ public:
     return {triangle_connectivity().at(face).begin(), triangle_connectivity().at(face).end()};
   }
 
-  virtual std::vector<MeshID> get_face_elements(MeshID face) const override {
+  virtual MeshID get_boundary_face_element(MeshID face) const override {
     const auto& tri = triangle_connectivity().at(face);
 
-    std::vector<MeshID> elements;
     for (size_t i = 0; i < tetrahedron_connectivity_.size(); ++i) {
       auto tet_faces_conn = tet_faces(tetrahedron_connectivity_[i]);
       for (const auto& tet_face : tet_faces_conn) {
@@ -230,12 +229,11 @@ public:
         std::sort(sorted_face.begin(), sorted_face.end());
         std::sort(sorted_tet_face.begin(), sorted_tet_face.end());
         if (sorted_face == sorted_tet_face) {
-          elements.push_back(static_cast<MeshID>(i));
-          break;
+          return static_cast<MeshID>(i);
         }
       }
     }
-    return elements;
+    return ID_NONE;
   }
 
   // Other

--- a/tests/mesh_mock.h
+++ b/tests/mesh_mock.h
@@ -218,6 +218,26 @@ public:
     return {triangle_connectivity().at(face).begin(), triangle_connectivity().at(face).end()};
   }
 
+  virtual std::vector<MeshID> get_face_elements(MeshID face) const override {
+    const auto& tri = triangle_connectivity().at(face);
+
+    std::vector<MeshID> elements;
+    for (size_t i = 0; i < tetrahedron_connectivity_.size(); ++i) {
+      auto tet_faces_conn = tet_faces(tetrahedron_connectivity_[i]);
+      for (const auto& tet_face : tet_faces_conn) {
+        std::array<int, 3> sorted_face = tri;
+        std::array<int, 3> sorted_tet_face = tet_face;
+        std::sort(sorted_face.begin(), sorted_face.end());
+        std::sort(sorted_tet_face.begin(), sorted_tet_face.end());
+        if (sorted_face == sorted_tet_face) {
+          elements.push_back(static_cast<MeshID>(i));
+          break;
+        }
+      }
+    }
+    return elements;
+  }
+
   // Other
   virtual MeshLibrary mesh_library() const override { return MeshLibrary::MOCK; }
 

--- a/tests/test_boundary_faces.cpp
+++ b/tests/test_boundary_faces.cpp
@@ -1,0 +1,54 @@
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+// for testing
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+// xdg includes
+#include "xdg/xdg.h"
+#include "xdg/constants.h"
+#include "xdg/mesh_managers.h"
+
+#include "mesh_mock.h"
+#include "util.h"
+
+using namespace xdg;
+using namespace xdg::test;
+
+
+TEMPLATE_TEST_CASE("Test Boundary Face Element Brick", "[boundary_faces]", MOAB_Interface, LibMesh_Interface)
+{
+  constexpr auto mesh_backend = TestType::value;
+
+  DYNAMIC_SECTION(fmt::format("Backend = {}", mesh_backend)) {
+    check_mesh_library_supported(mesh_backend);
+    std::shared_ptr<XDG> xdg = XDG::create(mesh_backend);
+    REQUIRE(xdg->mesh_manager()->mesh_library() == mesh_backend);
+    const auto& mesh_manager = xdg->mesh_manager();
+
+    const std::string filename = std::string("jezebel.") +
+      (mesh_backend == MeshLibrary::MOAB ? "h5m" : "exo");
+    mesh_manager->load_file(filename);
+    mesh_manager->init();
+
+    for (const auto surface : mesh_manager->surfaces()) {
+      for (const auto face : mesh_manager->get_surface_faces(surface)) {
+        const auto face_conn = mesh_manager->face_connectivity(face);
+        const auto element = mesh_manager->get_boundary_face_element(face);
+
+        REQUIRE(element != ID_NONE);
+
+        const auto elem_conn = mesh_manager->element_connectivity(element);
+        for (const auto vertex : face_conn) {
+          REQUIRE(std::find(elem_conn.begin(), elem_conn.end(), vertex) != elem_conn.end());
+        }
+      }
+    }
+  }
+}

--- a/tests/test_libmesh.cpp
+++ b/tests/test_libmesh.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Test BVH Build Brick")
   REQUIRE(ray_tracing_interface->num_registered_trees() == 3);
 }
 
-TEST_CASE("Test Face Elements Brick")
+TEST_CASE("Test Boundary Face Element Brick")
 {
   std::unique_ptr<MeshManager> mesh_manager  {std::make_unique<LibMeshManager>()};
 
@@ -74,16 +74,13 @@ TEST_CASE("Test Face Elements Brick")
   for (const auto surface : mesh_manager->surfaces()) {
     for (const auto face : mesh_manager->get_surface_faces(surface)) {
       const auto face_conn = mesh_manager->face_connectivity(face);
-      const auto adjacent_elements = mesh_manager->get_face_elements(face);
+      const auto element = mesh_manager->get_boundary_face_element(face);
 
-      REQUIRE(!adjacent_elements.empty());
-      REQUIRE(adjacent_elements.size() <= 2);
+      REQUIRE(element != ID_NONE);
 
-      for (const auto element : adjacent_elements) {
-        const auto elem_conn = mesh_manager->element_connectivity(element);
-        for (const auto vertex : face_conn) {
-          REQUIRE(std::find(elem_conn.begin(), elem_conn.end(), vertex) != elem_conn.end());
-        }
+      const auto elem_conn = mesh_manager->element_connectivity(element);
+      for (const auto vertex : face_conn) {
+        REQUIRE(std::find(elem_conn.begin(), elem_conn.end(), vertex) != elem_conn.end());
       }
     }
   }

--- a/tests/test_libmesh.cpp
+++ b/tests/test_libmesh.cpp
@@ -64,28 +64,6 @@ TEST_CASE("Test BVH Build Brick")
   REQUIRE(ray_tracing_interface->num_registered_trees() == 3);
 }
 
-TEST_CASE("Test Boundary Face Element Brick")
-{
-  std::unique_ptr<MeshManager> mesh_manager  {std::make_unique<LibMeshManager>()};
-
-  mesh_manager->load_file("brick.exo");
-  mesh_manager->init();
-
-  for (const auto surface : mesh_manager->surfaces()) {
-    for (const auto face : mesh_manager->get_surface_faces(surface)) {
-      const auto face_conn = mesh_manager->face_connectivity(face);
-      const auto element = mesh_manager->get_boundary_face_element(face);
-
-      REQUIRE(element != ID_NONE);
-
-      const auto elem_conn = mesh_manager->element_connectivity(element);
-      for (const auto vertex : face_conn) {
-        REQUIRE(std::find(elem_conn.begin(), elem_conn.end(), vertex) != elem_conn.end());
-      }
-    }
-  }
-}
-
 TEST_CASE("Test BVH Build Brick w/ Sidesets")
 {
   std::shared_ptr<MeshManager> mesh_manager = std::make_shared<LibMeshManager>();

--- a/tests/test_libmesh.cpp
+++ b/tests/test_libmesh.cpp
@@ -1,4 +1,5 @@
 // stl includes
+#include <algorithm>
 #include <iostream>
 #include <memory>
 
@@ -61,6 +62,31 @@ TEST_CASE("Test BVH Build Brick")
 
   // volume elements will be detected on the libmesh mesh, so three trees will be registered
   REQUIRE(ray_tracing_interface->num_registered_trees() == 3);
+}
+
+TEST_CASE("Test Face Elements Brick")
+{
+  std::unique_ptr<MeshManager> mesh_manager  {std::make_unique<LibMeshManager>()};
+
+  mesh_manager->load_file("brick.exo");
+  mesh_manager->init();
+
+  for (const auto surface : mesh_manager->surfaces()) {
+    for (const auto face : mesh_manager->get_surface_faces(surface)) {
+      const auto face_conn = mesh_manager->face_connectivity(face);
+      const auto adjacent_elements = mesh_manager->get_face_elements(face);
+
+      REQUIRE(!adjacent_elements.empty());
+      REQUIRE(adjacent_elements.size() <= 2);
+
+      for (const auto element : adjacent_elements) {
+        const auto elem_conn = mesh_manager->element_connectivity(element);
+        for (const auto vertex : face_conn) {
+          REQUIRE(std::find(elem_conn.begin(), elem_conn.end(), vertex) != elem_conn.end());
+        }
+      }
+    }
+  }
 }
 
 TEST_CASE("Test BVH Build Brick w/ Sidesets")

--- a/tests/test_mesh_connectivity.cpp
+++ b/tests/test_mesh_connectivity.cpp
@@ -70,17 +70,17 @@ TEST_CASE("Face Vertices (MeshMock)", "[surface][unit]") {
   }
 }
 
-TEST_CASE("Face Elements (MeshMock)", "[surface][unit]") {
+TEST_CASE("Boundary Face Element (MeshMock)", "[surface][unit]") {
   auto mock_mesh = std::make_shared<MeshMock>();
   std::shared_ptr<MeshManager> mesh_manager = mock_mesh;
   mesh_manager->init();
 
   for (MeshID face = 0; face < static_cast<MeshID>(mock_mesh->triangle_connectivity().size()); ++face) {
-    const auto elements = mesh_manager->get_face_elements(face);
-    REQUIRE(elements.size() == 1);
+    const auto element = mesh_manager->get_boundary_face_element(face);
+    REQUIRE(element != ID_NONE);
 
     const auto& tri = mock_mesh->triangle_connectivity().at(face);
-    const auto& tet = mock_mesh->tetrahedron_connectivity().at(elements[0]);
+    const auto& tet = mock_mesh->tetrahedron_connectivity().at(element);
     const auto tet_faces = mock_mesh->tet_faces(tet);
 
     bool found_match = false;

--- a/tests/test_mesh_connectivity.cpp
+++ b/tests/test_mesh_connectivity.cpp
@@ -70,6 +70,33 @@ TEST_CASE("Face Vertices (MeshMock)", "[surface][unit]") {
   }
 }
 
+TEST_CASE("Face Elements (MeshMock)", "[surface][unit]") {
+  auto mock_mesh = std::make_shared<MeshMock>();
+  std::shared_ptr<MeshManager> mesh_manager = mock_mesh;
+  mesh_manager->init();
+
+  for (MeshID face = 0; face < static_cast<MeshID>(mock_mesh->triangle_connectivity().size()); ++face) {
+    const auto elements = mesh_manager->get_face_elements(face);
+    REQUIRE(elements.size() == 1);
+
+    const auto& tri = mock_mesh->triangle_connectivity().at(face);
+    const auto& tet = mock_mesh->tetrahedron_connectivity().at(elements[0]);
+    const auto tet_faces = mock_mesh->tet_faces(tet);
+
+    bool found_match = false;
+    for (auto tet_face : tet_faces) {
+      std::sort(tet_face.begin(), tet_face.end());
+      auto sorted_tri = tri;
+      std::sort(sorted_tri.begin(), sorted_tri.end());
+      if (tet_face == sorted_tri) {
+        found_match = true;
+        break;
+      }
+    }
+    REQUIRE(found_match);
+  }
+}
+
 TEST_CASE("Get Surface Connectivity (MeshMock)", "[surface][unit]") {
   auto mock_mesh = std::make_shared<MeshMock>();
   std::shared_ptr<MeshManager> mesh_manager = mock_mesh;

--- a/tests/test_tracks.cpp
+++ b/tests/test_tracks.cpp
@@ -1,15 +1,25 @@
+#include <algorithm>
+#include <numeric>
 #include <random>
+#include <string>
+#include <vector>
 
 // for testing
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
+#include <catch2/catch_template_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 // xdg includes
 #include "xdg/xdg.h"
 #include "xdg/constants.h"
+#include "xdg/mesh_managers.h"
 
 #include "mesh_mock.h"
+#include "util.h"
+
+using namespace xdg;
+using namespace xdg::test;
 
 
 TEST_CASE("Test Internal Tracks")
@@ -111,5 +121,172 @@ TEST_CASE("Test Random Internal Tracks")
         return sum + segment.second;
       });
     REQUIRE(total_length == Catch::Approx((start-end).length()).epsilon(0.00001));
+  }
+}
+
+TEMPLATE_TEST_CASE("Test Single Tet Vertex Tangent Tracks", "[tracks]",
+                   MOAB_Interface,
+                   LibMesh_Interface)
+{
+  constexpr auto mesh_backend = TestType::value;
+
+  DYNAMIC_SECTION(fmt::format("Backend = {}", mesh_backend))
+  {
+    // Run this geometry case for each mesh backend that is available in the build.
+    check_mesh_library_supported(mesh_backend);
+    check_ray_tracer_supported(RTLibrary::EMBREE);
+
+    // Load the same single-tetrahedron mesh through the backend's native file format.
+    std::shared_ptr<XDG> xdg = XDG::create(mesh_backend, RTLibrary::EMBREE);
+    const auto& mm = xdg->mesh_manager();
+    const std::string file = std::string("single-tet.") +
+      (mesh_backend == MeshLibrary::MOAB ? "h5m" : "exo");
+    mm->load_file(file);
+    mm->init();
+    mm->parse_metadata();
+
+    // Confirm the fixture is the intended one-real-tet model, ignoring the implicit complement.
+    REQUIRE(mm->num_vertices() == 4);
+    const auto volume_it = std::find_if(mm->volumes().begin(), mm->volumes().end(),
+        [&](MeshID volume) {
+          return volume != mm->implicit_complement() &&
+                 mm->num_volume_elements(volume) == 1;
+        });
+    REQUIRE(volume_it != mm->volumes().end());
+    const MeshID volume = *volume_it;
+    REQUIRE(mm->num_volume_elements(volume) == 1);
+    const auto volume_elements = mm->get_volume_elements(volume);
+    REQUIRE(volume_elements.size() == 1);
+    const auto tet_vertices = mm->element_vertices(volume_elements.front());
+
+    xdg->prepare_raytracer();
+
+    // Make the track long enough to cross the whole model if it were not tangent.
+    const auto bbox = mm->global_bounding_box();
+    const double track_length = bbox.max_chord_length() * 2.0;
+    const double half_length = 0.5 * track_length;
+    size_t n_vertex_tangent_cases = 0;
+
+    // Build tracks through face vertices along each face normal. These lines touch
+    // the tetrahedron at a vertex only, so they should tally no element length.
+    for (const auto surface : mm->get_volume_surfaces(volume)) {
+      for (const auto face : mm->get_surface_faces(surface)) {
+        const Direction direction = mm->face_normal(face);
+        const auto vertices = mm->face_vertices(face);
+
+        for (const auto& vertex : vertices) {
+          // Exclude tracks that also run along a tet edge; those are edge-overlap
+          // cases and can have nonzero edge length even though they pass a vertex.
+          const auto line_contains_tet_edge = std::any_of(tet_vertices.begin(), tet_vertices.end(),
+              [&](const Vertex& tet_vertex) {
+                if (tet_vertex == vertex) return false;
+                return ((tet_vertex - vertex).cross(direction)).length() < 1e-12;
+              });
+          if (line_contains_tet_edge) continue;
+
+          const Position start = vertex - direction * half_length;
+          const Position end = vertex + direction * half_length;
+
+          std::vector<std::pair<MeshID, double>> track_segments;
+          REQUIRE_NOTHROW([&]() { track_segments = xdg->segments(start, end); }());
+
+          const double total_length = std::accumulate(
+              track_segments.begin(), track_segments.end(), 0.0,
+              [](double sum, const std::pair<MeshID, double>& segment) {
+                return sum + segment.second;
+              });
+
+          DYNAMIC_SECTION(fmt::format("Backend = {}, Face = {}, Vertex = {}", mesh_backend, face, vertex))
+          {
+            ++n_vertex_tangent_cases;
+            // A vertex-only tangent contact should contribute zero distance to the tet.
+            REQUIRE(total_length == Catch::Approx(0.0).margin(1e-12));
+          }
+        }
+      }
+    }
+    // Guard against accidentally filtering out the entire test fixture.
+    REQUIRE(n_vertex_tangent_cases > 0);
+  }
+}
+
+TEMPLATE_TEST_CASE("Test Single Tet Centroid To Vertex Tracks", "[tracks]",
+                   MOAB_Interface,
+                   LibMesh_Interface)
+{
+  constexpr auto mesh_backend = TestType::value;
+
+  DYNAMIC_SECTION(fmt::format("Backend = {}", mesh_backend))
+  {
+    // Run this geometry case for each mesh backend that is available in the build.
+    check_mesh_library_supported(mesh_backend);
+    check_ray_tracer_supported(RTLibrary::EMBREE);
+
+    // Load the same single-tetrahedron mesh through the backend's native file format.
+    std::shared_ptr<XDG> xdg = XDG::create(mesh_backend, RTLibrary::EMBREE);
+    const auto& mm = xdg->mesh_manager();
+    const std::string file = std::string("single-tet.") +
+      (mesh_backend == MeshLibrary::MOAB ? "h5m" : "exo");
+    mm->load_file(file);
+    mm->init();
+    mm->parse_metadata();
+
+    // Confirm the fixture is the intended one-real-tet model, ignoring the implicit complement.
+    REQUIRE(mm->num_vertices() == 4);
+    const auto volume_it = std::find_if(mm->volumes().begin(), mm->volumes().end(),
+        [&](MeshID volume) {
+          return volume != mm->implicit_complement() &&
+                 mm->num_volume_elements(volume) == 1;
+        });
+    REQUIRE(volume_it != mm->volumes().end());
+    const MeshID volume = *volume_it;
+    const auto volume_elements = mm->get_volume_elements(volume);
+    REQUIRE(volume_elements.size() == 1);
+    const auto tet_vertices = mm->element_vertices(volume_elements.front());
+
+    xdg->prepare_raytracer();
+
+    // The centroid is strictly inside the tet, so a track from the centroid
+    // through any vertex should tally the centroid-to-vertex distance.
+    Position centroid {0.0, 0.0, 0.0};
+    for (const auto& vertex : tet_vertices) {
+      centroid += vertex;
+    }
+    centroid /= static_cast<double>(tet_vertices.size());
+
+    const auto bbox = mm->global_bounding_box();
+    const double outside_extension = bbox.max_chord_length();
+
+    for (const auto& vertex : tet_vertices) {
+      const Direction direction = (vertex - centroid).normalize();
+      const Position outside = vertex + direction * outside_extension;
+      const double expected_length = (vertex - centroid).length();
+
+      // This is the directed vertex-crossing test: first tally from the
+      // interior centroid out through the vertex, then supply the same segment
+      // in reverse and require an identical tallied distance.
+      std::vector<std::pair<MeshID, double>> forward_segments;
+      std::vector<std::pair<MeshID, double>> reverse_segments;
+      REQUIRE_NOTHROW([&]() { forward_segments = xdg->segments(centroid, outside); }());
+      REQUIRE_NOTHROW([&]() { reverse_segments = xdg->segments(outside, centroid); }());
+
+      const double forward_length = std::accumulate(
+          forward_segments.begin(), forward_segments.end(), 0.0,
+          [](double sum, const std::pair<MeshID, double>& segment) {
+            return sum + segment.second;
+          });
+      const double reverse_length = std::accumulate(
+          reverse_segments.begin(), reverse_segments.end(), 0.0,
+          [](double sum, const std::pair<MeshID, double>& segment) {
+            return sum + segment.second;
+          });
+
+      DYNAMIC_SECTION(fmt::format("Backend = {}, Vertex = {}", mesh_backend, vertex))
+      {
+        REQUIRE(forward_length == Catch::Approx(expected_length).epsilon(0.00001));
+        REQUIRE(reverse_length == Catch::Approx(expected_length).epsilon(0.00001));
+        REQUIRE(forward_length == Catch::Approx(reverse_length).epsilon(0.00001));
+      }
+    }
   }
 }

--- a/tests/test_tracks.cpp
+++ b/tests/test_tracks.cpp
@@ -124,7 +124,7 @@ TEST_CASE("Test Random Internal Tracks")
   }
 }
 
-TEMPLATE_TEST_CASE("Test Single Tet Vertex Tangent Tracks", "[tracks]",
+TEMPLATE_TEST_CASE("Test Single-Tet Glancing Vertex Intersection Tracks", "[tracks]",
                    MOAB_Interface,
                    LibMesh_Interface)
 {
@@ -145,23 +145,15 @@ TEMPLATE_TEST_CASE("Test Single Tet Vertex Tangent Tracks", "[tracks]",
     mm->init();
     mm->parse_metadata();
 
-    // Confirm the fixture is the intended one-real-tet model, ignoring the implicit complement.
-    REQUIRE(mm->num_vertices() == 4);
-    const auto volume_it = std::find_if(mm->volumes().begin(), mm->volumes().end(),
-        [&](MeshID volume) {
-          return volume != mm->implicit_complement() &&
-                 mm->num_volume_elements(volume) == 1;
-        });
-    REQUIRE(volume_it != mm->volumes().end());
-    const MeshID volume = *volume_it;
+    MeshID volume = 1;
+    // Ensure that the volume is the intended volume containing a single tet
     REQUIRE(mm->num_volume_elements(volume) == 1);
     const auto volume_elements = mm->get_volume_elements(volume);
-    REQUIRE(volume_elements.size() == 1);
     const auto tet_vertices = mm->element_vertices(volume_elements.front());
 
     xdg->prepare_raytracer();
 
-    // Make the track long enough to cross the whole model if it were not tangent.
+    // Make the track long enough to cross the whole model to ensure intersection
     const auto bbox = mm->global_bounding_box();
     const double track_length = bbox.max_chord_length() * 2.0;
     const double half_length = 0.5 * track_length;
@@ -199,7 +191,7 @@ TEMPLATE_TEST_CASE("Test Single Tet Vertex Tangent Tracks", "[tracks]",
           DYNAMIC_SECTION(fmt::format("Backend = {}, Face = {}, Vertex = {}", mesh_backend, face, vertex))
           {
             ++n_vertex_tangent_cases;
-            // A vertex-only tangent contact should contribute zero distance to the tet.
+            // A vertex-only tangent contact should effectivly contribute zero distance to the tet.
             REQUIRE(total_length == Catch::Approx(0.0).margin(1e-12));
           }
         }
@@ -210,7 +202,7 @@ TEMPLATE_TEST_CASE("Test Single Tet Vertex Tangent Tracks", "[tracks]",
   }
 }
 
-TEMPLATE_TEST_CASE("Test Single Tet Centroid To Vertex Tracks", "[tracks]",
+TEMPLATE_TEST_CASE("Test Single-Tet Vertex Intersection Tracks", "[tracks]",
                    MOAB_Interface,
                    LibMesh_Interface)
 {
@@ -231,17 +223,10 @@ TEMPLATE_TEST_CASE("Test Single Tet Centroid To Vertex Tracks", "[tracks]",
     mm->init();
     mm->parse_metadata();
 
-    // Confirm the fixture is the intended one-real-tet model, ignoring the implicit complement.
-    REQUIRE(mm->num_vertices() == 4);
-    const auto volume_it = std::find_if(mm->volumes().begin(), mm->volumes().end(),
-        [&](MeshID volume) {
-          return volume != mm->implicit_complement() &&
-                 mm->num_volume_elements(volume) == 1;
-        });
-    REQUIRE(volume_it != mm->volumes().end());
-    const MeshID volume = *volume_it;
+    MeshID volume = 1;
+    // Ensure that the volume is the intended volume containing a single tet
+    REQUIRE(mm->num_volume_elements(volume) == 1);
     const auto volume_elements = mm->get_volume_elements(volume);
-    REQUIRE(volume_elements.size() == 1);
     const auto tet_vertices = mm->element_vertices(volume_elements.front());
 
     xdg->prepare_raytracer();

--- a/tests/test_tracks.cpp
+++ b/tests/test_tracks.cpp
@@ -107,8 +107,6 @@ TEST_CASE("Test Random Internal Tracks")
     start = {x_dist(gen), y_dist(gen), z_dist(gen)};
     end = {x_dist(gen), y_dist(gen), z_dist(gen)};
 
-    std::cout << "Start: " << start << ", End: " << end << std::endl;
-
     // check that the segments are valid
     auto track_segments = xdg->segments(volume_id, start, end);
     // at least one segement should always be generated
@@ -188,12 +186,11 @@ TEMPLATE_TEST_CASE("Test Single-Tet Glancing Vertex Intersection Tracks", "[trac
                 return sum + segment.second;
               });
 
-          DYNAMIC_SECTION(fmt::format("Backend = {}, Face = {}, Vertex = {}", mesh_backend, face, vertex))
-          {
-            ++n_vertex_tangent_cases;
-            // A vertex-only tangent contact should effectivly contribute zero distance to the tet.
-            REQUIRE(total_length == Catch::Approx(0.0).margin(1e-12));
-          }
+          INFO(fmt::format("Backend = {}, Face = {}, Vertex = {}", mesh_backend, face, vertex));
+          ++n_vertex_tangent_cases;
+          // A vertex-only tangent contact should effectivly contribute zero distance to the tet.
+          REQUIRE(total_length == Catch::Approx(0.0).margin(1e-12));
+
         }
       }
     }
@@ -266,12 +263,10 @@ TEMPLATE_TEST_CASE("Test Single-Tet Vertex Intersection Tracks", "[tracks]",
             return sum + segment.second;
           });
 
-      DYNAMIC_SECTION(fmt::format("Backend = {}, Vertex = {}", mesh_backend, vertex))
-      {
-        REQUIRE(forward_length == Catch::Approx(expected_length).epsilon(0.00001));
-        REQUIRE(reverse_length == Catch::Approx(expected_length).epsilon(0.00001));
-        REQUIRE(forward_length == Catch::Approx(reverse_length).epsilon(0.00001));
-      }
+      INFO(fmt::format("Backend = {}, Vertex = {}", mesh_backend, vertex));
+      REQUIRE(forward_length == Catch::Approx(expected_length).epsilon(0.00001));
+      REQUIRE(reverse_length == Catch::Approx(expected_length).epsilon(0.00001));
+      REQUIRE(forward_length == Catch::Approx(reverse_length).epsilon(0.00001));
     }
   }
 }


### PR DESCRIPTION
This contains a set of changes to allow the `XDG::sgements` call to use mesh adjacencies when finding an entering intersection into the volumetric mesh. `XDG::segments` is the primary call used to separate particle tracks for superimposed tally meshes in particle transport.

Currently, a finite ray given to `segments` can undergo a glancing intersection with a face when attempting to enter/re-enter the mesh. The query performed at the intersection location + a small amount can result in a failure to find an element in these cases, causing the method to return early as a result as it becomes unclear how to proceed in determining if the ray intersects any additional elements along it's length. This can prevent subsequent ray segments volumetric beyond this glancing intersection from being recorded.

The updates here use a new `get_boundary_face_element` to enter the element adjacent to the face. Meshes and transport simulations that have previously raise the warning in `segments` regarding failure to find an element after an intersection no longer do in this scenario and tally results match other tracklength estimator schemes in OpenMC. Further testing is warranted, however -- particularly integrated testing in the repo itself. While a good amount of testing was done for superimposed meshes that partially covered the domain, I don't think the geometries were such that glancing intersections were likely. We can now improve on this in benchmark and integrated testing.

The new `get_boundary_face_element` method is named as such because for MOAB meshes only these adjacencies are established in the direct access manager.

# Alternatives

When the `find_element` call fails at the entering intersection location, fire another ray from the location + `TINY_BIT` under the assumption that the initial intersection discovered is a glancing intersection and repeat this process at the next intersection location should one be found closer than what distance remains for the finite ray. This option likely isn't as robust as entering an element via adjacencies nor is it as performant due to the (now) unecessary `find_element` call when entering a volumetric mesh element.


TODO:

- [x] Provide tally equivalence data
- [x] Add pathological test case