### PR TITLE
Explicitly set type of parameters in particle sim arguments

### DIFF
--- a/tools/particle_sim.cpp
+++ b/tools/particle_sim.cpp
@@ -31,11 +31,11 @@ args.add_argument("-m", "--mfp")
     .help("Mean free path of the particles").scan<'g', double>();
 
 args.add_argument("-n", "--n-particles")
-    .default_value(100)
+    .default_value(uint32_t{100})
     .help("Number of particles to simulate").scan<'u', uint32_t>();
 
 args.add_argument("-e", "--max-events")
-    .default_value(1000)
+    .default_value(uint32_t{1000})
     .help("Maximum number of events per particle").scan<'u', uint32_t>();
 
 args.add_argument("-g", "--ipc-graveyard")

--- a/tools/particle_sim.cpp
+++ b/tools/particle_sim.cpp
@@ -31,11 +31,11 @@ args.add_argument("-m", "--mfp")
     .help("Mean free path of the particles").scan<'g', double>();
 
 args.add_argument("-n", "--n-particles")
-    .default_value(uint32_t{100})
+    .default_value(100u)
     .help("Number of particles to simulate").scan<'u', uint32_t>();
 
 args.add_argument("-e", "--max-events")
-    .default_value(uint32_t{1000})
+    .default_value(1000u)
     .help("Maximum number of events per particle").scan<'u', uint32_t>();
 
 args.add_argument("-g", "--ipc-graveyard")


### PR DESCRIPTION
Was running into an error when not passing the number of particles explicitly into the particle sim: 
```
#9  0x0000555555575428 in std::__throw_bad_any_cast () at /usr/include/c++/11/any:63
#10 0x0000555555590181 in std::any_cast<unsigned int> (__any=std::any containing int = {...}) at /usr/include/c++/11/any:470
#11 0x000055555558b3f0 in argparse::Argument::get<unsigned int> (this=0x5555556555f0)
    at /home/waqar/xdg/vendor/argparse/include/argparse/argparse.hpp:1530
#12 0x0000555555584c6f in argparse::ArgumentParser::get<unsigned int> (this=0x7fffffffcdb0, arg_name="--n-particles")
    at /home/waqar/xdg/vendor/argparse/include/argparse/argparse.hpp:1902
#13 0x0000555555572dfb in main (argc=2, argv=0x7fffffffd0f8) at /home/waqar/xdg/tools/particle_sim.cpp:105
```
Seems like the default values were setting the types as `int` and argparse was failing since it was explicitly expecting `uint`. 

**This PR ensures default values are explicitly set as `uint`**