### PR TITLE
Ensure BLAS only built once per surface with GPRT

### DIFF
--- a/include/xdg/geometry/plucker.h
+++ b/include/xdg/geometry/plucker.h
@@ -25,8 +25,6 @@ struct PluckerIntersectionResult {
   double t = 0.0;      // Distance along the ray to the intersection point
 };
 
-constexpr PluckerIntersectionResult EXIT_EARLY = {false, 0.0};
-
 /* Function to return the vertex with the lowest coordinates. To force the same
   ray-edge computation, the Plücker test needs to use consistent edge
   representation. This would be more simple with MOAB handles instead of
@@ -81,7 +79,7 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
   // If orientation is set, confirm that sign of plucker_coordinate indicate
   // correct orientation of intersection
   if (useOrientation && orientation * plucker_coord0 > 0) {
-    return EXIT_EARLY;
+    return {false, 0.0};
   }
 
   // Determine the value of the second Plucker coordinate from edge 1
@@ -92,13 +90,13 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
   // correct orientation of intersection
   if (useOrientation) {
     if (orientation * plucker_coord1 > 0) {
-      return EXIT_EARLY;
+      return {false, 0.0};
     }
     // If the orientation is not specified, all plucker_coords must be the same
     // sign or zero.
   } else if ((0.0 < plucker_coord0 && 0.0 > plucker_coord1) ||
              (0.0 > plucker_coord0 && 0.0 < plucker_coord1)) {
-    return EXIT_EARLY;
+    return {false, 0.0};
   }
 
   // Determine the value of the third Plucker coordinate from edge 2
@@ -109,7 +107,7 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
   // correct orientation of intersection
   if (useOrientation) {
     if (orientation * plucker_coord2 > 0) {
-      return EXIT_EARLY;
+      return {false, 0.0};
     }
     // If the orientation is not specified, all plucker_coords must be the same
     // sign or zero.
@@ -117,12 +115,12 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
              (0.0 > plucker_coord1 && 0.0 < plucker_coord2) ||
              (0.0 < plucker_coord0 && 0.0 > plucker_coord2) ||
              (0.0 > plucker_coord0 && 0.0 < plucker_coord2)) {
-    return EXIT_EARLY;
+    return {false, 0.0};
   }
 
   // check for coplanar case to avoid dividing by zero
   if (0.0 == plucker_coord0 && 0.0 == plucker_coord1 && 0.0 == plucker_coord2) {
-    return EXIT_EARLY;
+    return {false, 0.0};
   }
 
   // get the distance to intersection
@@ -155,7 +153,7 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
   }
 
   // is the intersection within distance limits?
-  if (dist_out < tMin || dist_out > tMax) return EXIT_EARLY;
+  if (dist_out < tMin || dist_out > tMax) return {false, 0.0};
 
   return {true, dist_out};
 }

--- a/include/xdg/geometry/plucker.h
+++ b/include/xdg/geometry/plucker.h
@@ -25,6 +25,8 @@ struct PluckerIntersectionResult {
   double t = 0.0;      // Distance along the ray to the intersection point
 };
 
+static constexpr PluckerIntersectionResult EXIT_EARLY = {false, 0.0};
+
 /* Function to return the vertex with the lowest coordinates. To force the same
   ray-edge computation, the Plücker test needs to use consistent edge
   representation. This would be more simple with MOAB handles instead of
@@ -79,7 +81,7 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
   // If orientation is set, confirm that sign of plucker_coordinate indicate
   // correct orientation of intersection
   if (useOrientation && orientation * plucker_coord0 > 0) {
-    return {false, 0.0};
+    return EXIT_EARLY;
   }
 
   // Determine the value of the second Plucker coordinate from edge 1
@@ -90,13 +92,13 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
   // correct orientation of intersection
   if (useOrientation) {
     if (orientation * plucker_coord1 > 0) {
-      return {false, 0.0};
+      return EXIT_EARLY;
     }
     // If the orientation is not specified, all plucker_coords must be the same
     // sign or zero.
   } else if ((0.0 < plucker_coord0 && 0.0 > plucker_coord1) ||
              (0.0 > plucker_coord0 && 0.0 < plucker_coord1)) {
-    return {false, 0.0};
+    return EXIT_EARLY;
   }
 
   // Determine the value of the third Plucker coordinate from edge 2
@@ -107,7 +109,7 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
   // correct orientation of intersection
   if (useOrientation) {
     if (orientation * plucker_coord2 > 0) {
-      return {false, 0.0};
+      return EXIT_EARLY;
     }
     // If the orientation is not specified, all plucker_coords must be the same
     // sign or zero.
@@ -115,12 +117,12 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
              (0.0 > plucker_coord1 && 0.0 < plucker_coord2) ||
              (0.0 < plucker_coord0 && 0.0 > plucker_coord2) ||
              (0.0 > plucker_coord0 && 0.0 < plucker_coord2)) {
-    return {false, 0.0};
+    return EXIT_EARLY;
   }
 
   // check for coplanar case to avoid dividing by zero
   if (0.0 == plucker_coord0 && 0.0 == plucker_coord1 && 0.0 == plucker_coord2) {
-    return {false, 0.0};
+    return EXIT_EARLY;
   }
 
   // get the distance to intersection
@@ -153,7 +155,7 @@ inline PluckerIntersectionResult plucker_ray_tri_intersect(dp::vec3 vertices[3],
   }
 
   // is the intersection within distance limits?
-  if (dist_out < tMin || dist_out > tMax) return {false, 0.0};
+  if (dist_out < tMin || dist_out > tMax) return EXIT_EARLY;
 
   return {true, dist_out};
 }

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -130,6 +130,7 @@ class GPRTRayTracer : public RayTracer {
     
     // Mesh-to-Scene maps 
     std::map<MeshID, GPRTGeomOf<DPTriangleGeomData>> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
+    std::map<MeshID, GPRTAccel> surface_to_blas_map_; //<! Map from mesh surface to GPRT BLAS
 
     // Internal GPRT Mappings
     std::unordered_map<SurfaceTreeID, GPRTAccel> surface_volume_tree_to_accel_map; // Map from XDG::TreeID to GPRTAccel for volume TLAS

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -112,6 +112,9 @@ class GPRTRayTracer : public RayTracer {
     
   private:
     void check_ray_buffer_capacity(size_t N);
+    
+    GPRTGeomOf<DPTriangleGeomData>
+    register_surface(const std::shared_ptr<MeshManager>& mesh_manager, MeshID surface_id);
 
     // GPRT objects 
     GPRTContext context_;

--- a/include/xdg/gprt/ray_tracer.h
+++ b/include/xdg/gprt/ray_tracer.h
@@ -2,6 +2,7 @@
 #define _XDG_GPRT_BASE_RAY_TRACING_INTERFACE_H
 
 #include <memory>
+#include <map>
 #include <vector>
 #include <unordered_map>
 
@@ -35,6 +36,14 @@ struct gprtRayHit {
   dblHit* devHitAddr = nullptr;
 
   bool is_valid() const { return capacity > 0 && ray && hit && devRayAddr && devHitAddr; }
+};
+
+struct GPRTSurfaceBuffers {
+  GPRTBufferOf<double3> vertices = nullptr;
+  GPRTBufferOf<float3> aabbs = nullptr;
+  GPRTBufferOf<uint3> connectivity = nullptr;
+  GPRTBufferOf<double3> normals = nullptr;
+  GPRTBufferOf<GPRTPrimitiveRef> primitive_refs = nullptr;
 };
 
 class GPRTRayTracer : public RayTracer {
@@ -129,11 +138,13 @@ class GPRTRayTracer : public RayTracer {
     uint32_t numRayTypes_ = 1; // <! Number of ray types. Allows multiple shaders to be set to the same geometery
     
     // Mesh-to-Scene maps 
-    std::map<MeshID, GPRTGeomOf<DPTriangleGeomData>> surface_to_geometry_map_; //<! Map from mesh surface to embree geometry
+    std::map<MeshID, GPRTGeomOf<DPTriangleGeomData>> surface_to_geometry_map_; //<! Map from mesh surface to GPRT geometry
     std::map<MeshID, GPRTAccel> surface_to_blas_map_; //<! Map from mesh surface to GPRT BLAS
+    std::map<MeshID, GPRTSurfaceBuffers> surface_buffers_map_; //<! Backing buffers for cached surface geometry
 
     // Internal GPRT Mappings
     std::unordered_map<SurfaceTreeID, GPRTAccel> surface_volume_tree_to_accel_map; // Map from XDG::TreeID to GPRTAccel for volume TLAS
+    std::unordered_map<SurfaceTreeID, GPRTBufferOf<gprt::Instance>> surface_tree_to_instance_buffer_map_; // Backing buffers for TLAS instances
     std::vector<GPRTAccel> blas_handles_; // Store BLAS handles so that they can be explicitly referenced in destructor
 
     // Global Tree IDs

--- a/include/xdg/gprt/shared_structs.h
+++ b/include/xdg/gprt/shared_structs.h
@@ -31,6 +31,8 @@ struct dblHit
 
 /* variables for double precision triangle mesh geometry */
 struct DPTriangleGeomData {
+  // TODO: There are definitely some redundant variables here once some of the
+  // other GPRT PRs are merged I will do a cleanup pass through the code
   double3 *vertex; // vertex buffer
   float3 *aabbs; // AABB buffer 
   uint3 *index;  // index buffer
@@ -45,6 +47,7 @@ struct DPTriangleGeomData {
   int reverse_tree; // TreeID of the reverse volume
   GPRTPrimitiveRef* primitive_refs;
   int num_faces; // Number of faces in the geometry
+  double bounding_box_bump; // Bounding box expansion for this geometry
 };
 
 struct dblRayGenData {

--- a/src/gprt/dbl_deviceCode.slang
+++ b/src/gprt/dbl_deviceCode.slang
@@ -123,8 +123,9 @@ populate_aabbs(uint3 DispatchThreadID: SV_DispatchThreadID, uniform DPTriangleGe
     dp::vec3 C = record.vertex[indices[2]];
     dp::vec3 dpaabbmin = min(min(A, B), C);
     dp::vec3 dpaabbmax = max(max(A, B), C);
-    float3 fpaabbmin = float3(dpaabbmin - float3(FLT_EPSILON, FLT_EPSILON, FLT_EPSILON));
-    float3 fpaabbmax = float3(dpaabbmax + float3(FLT_EPSILON, FLT_EPSILON, FLT_EPSILON));
+    dp::vec3 bump = dp::vec3(record.bounding_box_bump, record.bounding_box_bump, record.bounding_box_bump);
+    float3 fpaabbmin = float3(dpaabbmin - bump);
+    float3 fpaabbmax = float3(dpaabbmax + bump);
 
     record.aabbs[2 * primID] = fpaabbmin;
     record.aabbs[2 * primID + 1] = fpaabbmax;

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -46,6 +46,10 @@ GPRTRayTracer::~GPRTRayTracer()
     gprtAccelDestroy(accel);
   }
 
+  for (const auto& [tree, instance_buffer] : surface_tree_to_instance_buffer_map_) {
+    gprtBufferDestroy(instance_buffer);
+  }
+
   // Destroy BLAS structures
   for (const auto& blas : blas_handles_) {
     gprtAccelDestroy(blas);
@@ -58,6 +62,13 @@ GPRTRayTracer::~GPRTRayTracer()
   gprtGeomTypeDestroy(trianglesGeomType_);
 
   // Destroy Buffers
+  for (const auto& [surf, buffers] : surface_buffers_map_) {
+    gprtBufferDestroy(buffers.vertices);
+    gprtBufferDestroy(buffers.aabbs);
+    gprtBufferDestroy(buffers.connectivity);
+    gprtBufferDestroy(buffers.normals);
+    gprtBufferDestroy(buffers.primitive_refs);
+  }
   gprtBufferDestroy(rayHitBuffers_.ray);
   gprtBufferDestroy(rayHitBuffers_.hit);
   gprtBufferDestroy(excludePrimitivesBuffer_);
@@ -116,6 +127,7 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
     bool created_surface = false;
 
     if (!surface_to_geometry_map_.count(surf)) {
+      std::cout << "Creating geometry for surface " << surf << " in volume " << volume_id << std::endl;
       created_surface = true;
       auto num_faces = mesh_manager->num_surface_faces(surf);
       triangleGeom = gprtGeomCreate<DPTriangleGeomData>(context_, trianglesGeomType_);
@@ -150,20 +162,21 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
         primitive_refs.push_back(prim_ref);
       }
 
-      auto vertex_buffer = gprtDeviceBufferCreate<double3>(context_, dbl3Vertices.size(), dbl3Vertices.data());
-      auto aabb_buffer = gprtDeviceBufferCreate<float3>(context_, 2*num_faces, 0); // AABBs for each triangle
-      gprtAABBsSetPositions(triangleGeom, aabb_buffer, num_faces, 2*sizeof(float3), 0);
-      auto connectivity_buffer = gprtDeviceBufferCreate<uint3>(context_, ui3Indices.size(), ui3Indices.data());
-      auto normal_buffer = gprtDeviceBufferCreate<double3>(context_, num_faces, normals.data()); 
-      auto primitive_refs_buffer = gprtDeviceBufferCreate<GPRTPrimitiveRef>(context_, num_faces, primitive_refs.data()); // Buffer for primitive sense
+      GPRTSurfaceBuffers surface_buffers;
+      surface_buffers.vertices = gprtDeviceBufferCreate<double3>(context_, dbl3Vertices.size(), dbl3Vertices.data());
+      surface_buffers.aabbs = gprtDeviceBufferCreate<float3>(context_, 2*num_faces, 0); // AABBs for each triangle
+      gprtAABBsSetPositions(triangleGeom, surface_buffers.aabbs, num_faces, 2*sizeof(float3), 0);
+      surface_buffers.connectivity = gprtDeviceBufferCreate<uint3>(context_, ui3Indices.size(), ui3Indices.data());
+      surface_buffers.normals = gprtDeviceBufferCreate<double3>(context_, num_faces, normals.data()); 
+      surface_buffers.primitive_refs = gprtDeviceBufferCreate<GPRTPrimitiveRef>(context_, num_faces, primitive_refs.data()); // Buffer for primitive sense
 
-      geom_data->vertex = gprtBufferGetDevicePointer(vertex_buffer);
-      geom_data->index = gprtBufferGetDevicePointer(connectivity_buffer);
-      geom_data->aabbs = gprtBufferGetDevicePointer(aabb_buffer);
+      geom_data->vertex = gprtBufferGetDevicePointer(surface_buffers.vertices);
+      geom_data->index = gprtBufferGetDevicePointer(surface_buffers.connectivity);
+      geom_data->aabbs = gprtBufferGetDevicePointer(surface_buffers.aabbs);
       geom_data->ray = gprtBufferGetDevicePointer(rayHitBuffers_.ray);
       geom_data->surf_id = surf;
-      geom_data->normals = gprtBufferGetDevicePointer(normal_buffer);
-      geom_data->primitive_refs = gprtBufferGetDevicePointer(primitive_refs_buffer);
+      geom_data->normals = gprtBufferGetDevicePointer(surface_buffers.normals);
+      geom_data->primitive_refs = gprtBufferGetDevicePointer(surface_buffers.primitive_refs);
       geom_data->num_faces = num_faces;
       geom_data->bounding_box_bump = bump;
 
@@ -175,8 +188,11 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
 
       surface_to_geometry_map_[surf] = triangleGeom;
       surface_to_blas_map_[surf] = blas;
+      surface_buffers_map_[surf] = surface_buffers;
       blas_handles_.push_back(blas);
-    } else {
+    } 
+    else {
+      std::cout << "Reusing existing geometry for surface " << surf << " in volume " << volume_id << std::endl;
       triangleGeom = surface_to_geometry_map_.at(surf);
       blas = surface_to_blas_map_.at(surf);
       geom_data = gprtGeomGetParameters(triangleGeom);
@@ -214,6 +230,7 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
   GPRTAccel volume_tlas = gprtInstanceAccelCreate(context_, surfaceBlasInstances.size(), instanceBuffer);
   gprtAccelBuild(context_, volume_tlas, buildParams_);
   surface_volume_tree_to_accel_map[tree] = volume_tlas;
+  surface_tree_to_instance_buffer_map_[tree] = instanceBuffer;
   
   return tree;
 }
@@ -349,6 +366,7 @@ void GPRTRayTracer::create_global_surface_tree()
   SurfaceTreeID tree = next_surface_tree_id();
   surface_trees_.push_back(tree);
   surface_volume_tree_to_accel_map[tree] = global_accel;  
+  surface_tree_to_instance_buffer_map_[tree] = globalBuffer;
   global_surface_tree_ = tree;
   global_surface_accel_ = global_accel; 
 }

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -117,7 +117,6 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
   SurfaceTreeID tree = next_surface_tree_id();
   surface_trees_.push_back(tree);
   auto volume_surfaces = mesh_manager->get_volume_surfaces(volume_id);
-  auto bump = bounding_box_bump(mesh_manager, volume_id);
   std::vector<gprt::Instance> surfaceBlasInstances; // BLAS for each (surface) geometry in this volume
   surfaceBlasInstances.reserve(volume_surfaces.size());
 
@@ -125,12 +124,14 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
     GPRTGeomOf<DPTriangleGeomData> surfaceGeometry;
     GPRTAccel blas = nullptr;
     DPTriangleGeomData* geom_data = nullptr;
+    auto [forward_parent, reverse_parent] = mesh_manager->get_parent_volumes(surf);
+    auto max_parent_bbox_bump = std::max(bounding_box_bump(mesh_manager, forward_parent),
+                                         bounding_box_bump(mesh_manager, reverse_parent));
 
     if (!surface_to_geometry_map_.count(surf)) {
-      std::cout << "Creating geometry for surface " << surf << " in volume " << volume_id << std::endl;
       surfaceGeometry = register_surface(mesh_manager, surf);
       geom_data = gprtGeomGetParameters(surfaceGeometry);
-      geom_data->bounding_box_bump = bump;
+      geom_data->bounding_box_bump = max_parent_bbox_bump;
 
       gprtComputeLaunch(aabbPopulationProgram_,
                         {static_cast<uint32_t>(geom_data->num_faces), 1, 1},
@@ -144,24 +145,9 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
       surface_to_blas_map_[surf] = blas;
       blas_handles_.push_back(blas);
     } else {
-      std::cout << "Reusing existing geometry for surface " << surf << " in volume " << volume_id << std::endl;
       surfaceGeometry = surface_to_geometry_map_.at(surf);
       geom_data = gprtGeomGetParameters(surfaceGeometry);
       blas = surface_to_blas_map_.at(surf);
-
-      // If we have already visited surface update bump if necessary and rebuild BLAS if the AABBs have expanded
-      if (bump > geom_data->bounding_box_bump) {
-        geom_data->bounding_box_bump = bump;
-
-        gprtComputeLaunch(aabbPopulationProgram_,
-                          {static_cast<uint32_t>(geom_data->num_faces), 1, 1},
-                          {1, 1, 1},
-                          *geom_data);
-        gprtComputeSynchronize(context_);
-
-        // Rebuild the cached BLAS after the AABBs expand.
-        gprtAccelBuild(context_, blas, buildParams_);
-      }
     }
 
     gprt::Instance instance = gprtAccelGetInstance(blas);
@@ -169,7 +155,6 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
     surfaceBlasInstances.push_back(instance);
     
     // Always update per-volume info
-    auto [forward_parent, reverse_parent] = mesh_manager->surface_senses(surf);
     if (volume_id == forward_parent) {
       geom_data->forward_vol = forward_parent;
       geom_data->forward_tree = tree;

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -119,88 +119,47 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
   auto volume_surfaces = mesh_manager->get_volume_surfaces(volume_id);
   auto bump = bounding_box_bump(mesh_manager, volume_id);
   std::vector<gprt::Instance> surfaceBlasInstances; // BLAS for each (surface) geometry in this volume
+  surfaceBlasInstances.reserve(volume_surfaces.size());
 
   for (const auto &surf : volume_surfaces) {
-    GPRTGeomOf<DPTriangleGeomData> triangleGeom;
-    GPRTAccel blas;
+    GPRTGeomOf<DPTriangleGeomData> surfaceGeometry;
+    GPRTAccel blas = nullptr;
     DPTriangleGeomData* geom_data = nullptr;
-    bool created_surface = false;
 
     if (!surface_to_geometry_map_.count(surf)) {
       std::cout << "Creating geometry for surface " << surf << " in volume " << volume_id << std::endl;
-      created_surface = true;
-      auto num_faces = mesh_manager->num_surface_faces(surf);
-      triangleGeom = gprtGeomCreate<DPTriangleGeomData>(context_, trianglesGeomType_);
-      geom_data = gprtGeomGetParameters(triangleGeom); // pointer to assign data to
-
-      // Get storage for vertices
-      auto vertices = mesh_manager->get_surface_vertices(surf);
-      auto indices = mesh_manager->get_surface_connectivity(surf);
-      std::vector<double3> dbl3Vertices;
-      dbl3Vertices.reserve(vertices.size());
-      for (const auto &vertex : vertices) {
-        dbl3Vertices.push_back({vertex.x, vertex.y, vertex.z});
-      }
-
-      // Get storage for indices
-      std::vector<uint3> ui3Indices;
-      ui3Indices.reserve(indices.size() / 3);
-      for (size_t i = 0; i < indices.size(); i += 3) {
-        ui3Indices.emplace_back(indices[i], indices[i + 1], indices[i + 2]);
-      }
-
-      // Get storage for normals
-      std::vector<double3> normals;
-      std::vector<GPRTPrimitiveRef> primitive_refs;
-      primitive_refs.reserve(num_faces);
-      normals.reserve(num_faces);
-      for (const auto &face : mesh_manager->get_surface_faces(surf)) {
-        auto norm = mesh_manager->face_normal(face);
-        normals.push_back({norm.x, norm.y, norm.z});
-        GPRTPrimitiveRef prim_ref;
-        prim_ref.id = face;
-        primitive_refs.push_back(prim_ref);
-      }
-
-      GPRTSurfaceBuffers surface_buffers;
-      surface_buffers.vertices = gprtDeviceBufferCreate<double3>(context_, dbl3Vertices.size(), dbl3Vertices.data());
-      surface_buffers.aabbs = gprtDeviceBufferCreate<float3>(context_, 2*num_faces, 0); // AABBs for each triangle
-      gprtAABBsSetPositions(triangleGeom, surface_buffers.aabbs, num_faces, 2*sizeof(float3), 0);
-      surface_buffers.connectivity = gprtDeviceBufferCreate<uint3>(context_, ui3Indices.size(), ui3Indices.data());
-      surface_buffers.normals = gprtDeviceBufferCreate<double3>(context_, num_faces, normals.data()); 
-      surface_buffers.primitive_refs = gprtDeviceBufferCreate<GPRTPrimitiveRef>(context_, num_faces, primitive_refs.data()); // Buffer for primitive sense
-
-      geom_data->vertex = gprtBufferGetDevicePointer(surface_buffers.vertices);
-      geom_data->index = gprtBufferGetDevicePointer(surface_buffers.connectivity);
-      geom_data->aabbs = gprtBufferGetDevicePointer(surface_buffers.aabbs);
-      geom_data->ray = gprtBufferGetDevicePointer(rayHitBuffers_.ray);
-      geom_data->surf_id = surf;
-      geom_data->normals = gprtBufferGetDevicePointer(surface_buffers.normals);
-      geom_data->primitive_refs = gprtBufferGetDevicePointer(surface_buffers.primitive_refs);
-      geom_data->num_faces = num_faces;
+      surfaceGeometry = register_surface(mesh_manager, surf);
+      geom_data = gprtGeomGetParameters(surfaceGeometry);
       geom_data->bounding_box_bump = bump;
 
-      gprtComputeLaunch(aabbPopulationProgram_, {num_faces, 1, 1}, {1, 1, 1}, *geom_data);
+      gprtComputeLaunch(aabbPopulationProgram_,
+                        {static_cast<uint32_t>(geom_data->num_faces), 1, 1},
+                        {1, 1, 1},
+                        *geom_data);
       gprtComputeSynchronize(context_);
 
-      blas = gprtAABBAccelCreate(context_, triangleGeom, buildParams_.buildMode);
+      blas = gprtAABBAccelCreate(context_, surfaceGeometry, buildParams_.buildMode);
       gprtAccelBuild(context_, blas, buildParams_);
 
-      surface_to_geometry_map_[surf] = triangleGeom;
       surface_to_blas_map_[surf] = blas;
-      surface_buffers_map_[surf] = surface_buffers;
       blas_handles_.push_back(blas);
-    } 
-    else {
+    } else {
       std::cout << "Reusing existing geometry for surface " << surf << " in volume " << volume_id << std::endl;
-      triangleGeom = surface_to_geometry_map_.at(surf);
+      surfaceGeometry = surface_to_geometry_map_.at(surf);
+      geom_data = gprtGeomGetParameters(surfaceGeometry);
       blas = surface_to_blas_map_.at(surf);
-      geom_data = gprtGeomGetParameters(triangleGeom);
 
+      // If we have already visited surface update bump if necessary and rebuild BLAS if the AABBs have expanded
       if (bump > geom_data->bounding_box_bump) {
         geom_data->bounding_box_bump = bump;
-        gprtComputeLaunch(aabbPopulationProgram_, {geom_data->num_faces, 1, 1}, {1, 1, 1}, *geom_data);
+
+        gprtComputeLaunch(aabbPopulationProgram_,
+                          {static_cast<uint32_t>(geom_data->num_faces), 1, 1},
+                          {1, 1, 1},
+                          *geom_data);
         gprtComputeSynchronize(context_);
+
+        // Rebuild the cached BLAS after the AABBs expand.
         gprtAccelBuild(context_, blas, buildParams_);
       }
     }
@@ -208,12 +167,9 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
     gprt::Instance instance = gprtAccelGetInstance(blas);
     instance.mask = 0xff; // mask can be used to filter instances during ray traversal. 0xff ensures no filtering
     surfaceBlasInstances.push_back(instance);
-    if (created_surface) {
-      globalBlasInstances_.push_back(instance);
-    }
     
     // Always update per-volume info
-    auto [forward_parent, reverse_parent] = mesh_manager->get_parent_volumes(surf);
+    auto [forward_parent, reverse_parent] = mesh_manager->surface_senses(surf);
     if (volume_id == forward_parent) {
       geom_data->forward_vol = forward_parent;
       geom_data->forward_tree = tree;
@@ -233,6 +189,74 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
   surface_tree_to_instance_buffer_map_[tree] = instanceBuffer;
   
   return tree;
+}
+
+GPRTGeomOf<DPTriangleGeomData>
+GPRTRayTracer::register_surface(const std::shared_ptr<MeshManager>& mesh_manager, MeshID surface_id)
+{
+  auto triangleGeom = gprtGeomCreate<DPTriangleGeomData>(context_, trianglesGeomType_);
+  DPTriangleGeomData* geom_data = gprtGeomGetParameters(triangleGeom);
+
+  auto num_faces = mesh_manager->num_surface_faces(surface_id);
+  auto surface_faces = mesh_manager->get_surface_faces(surface_id);
+
+  // Get storage for vertices
+  auto vertices = mesh_manager->get_surface_vertices(surface_id);
+  std::vector<double3> dbl3Vertices;
+  dbl3Vertices.reserve(vertices.size());
+  for (const auto &vertex : vertices) {
+    dbl3Vertices.push_back({vertex.x, vertex.y, vertex.z});
+  }
+
+  // Get storage for indices
+  auto indices = mesh_manager->get_surface_connectivity(surface_id);
+  std::vector<uint3> ui3Indices;
+  ui3Indices.reserve(indices.size() / 3);
+  for (size_t i = 0; i < indices.size(); i += 3) {
+    ui3Indices.emplace_back(indices[i], indices[i + 1], indices[i + 2]);
+  }
+
+  // Get storage for normals
+  std::vector<double3> normals;
+  std::vector<GPRTPrimitiveRef> primitive_refs;
+  primitive_refs.reserve(num_faces);
+  normals.reserve(num_faces);
+  for (const auto &face : surface_faces) {
+    auto norm = mesh_manager->face_normal(face);
+    normals.push_back({norm.x, norm.y, norm.z});
+    GPRTPrimitiveRef prim_ref;
+    prim_ref.id = face;
+    primitive_refs.push_back(prim_ref);
+  }
+
+  // Create device buffers
+  GPRTSurfaceBuffers surface_buffers; // store in struct for lifetime management outside this function
+  surface_buffers.vertices = gprtDeviceBufferCreate<double3>(context_, dbl3Vertices.size(), dbl3Vertices.data());
+  surface_buffers.aabbs = gprtDeviceBufferCreate<float3>(context_, 2*num_faces, 0); // AABBs for each triangle
+  gprtAABBsSetPositions(triangleGeom, surface_buffers.aabbs, num_faces, 2*sizeof(float3), 0);
+  surface_buffers.connectivity = gprtDeviceBufferCreate<uint3>(context_, ui3Indices.size(), ui3Indices.data());
+  surface_buffers.normals = gprtDeviceBufferCreate<double3>(context_, num_faces, normals.data()); 
+  surface_buffers.primitive_refs = gprtDeviceBufferCreate<GPRTPrimitiveRef>(context_, num_faces, primitive_refs.data()); // Buffer for primitive sense
+
+  // Set user data for the triangle geometry
+  geom_data->vertex = gprtBufferGetDevicePointer(surface_buffers.vertices);
+  geom_data->index = gprtBufferGetDevicePointer(surface_buffers.connectivity);
+  geom_data->aabbs = gprtBufferGetDevicePointer(surface_buffers.aabbs);
+  geom_data->ray = gprtBufferGetDevicePointer(rayHitBuffers_.ray);
+  geom_data->surf_id = surface_id;
+  geom_data->normals = gprtBufferGetDevicePointer(surface_buffers.normals);
+  geom_data->primitive_refs = gprtBufferGetDevicePointer(surface_buffers.primitive_refs);
+  geom_data->num_faces = num_faces;
+  geom_data->bounding_box_bump = 0.0;
+  geom_data->forward_vol = ID_NONE;
+  geom_data->reverse_vol = ID_NONE;
+  geom_data->forward_tree = TREE_NONE;
+  geom_data->reverse_tree = TREE_NONE;
+
+  surface_to_geometry_map_[surface_id] = triangleGeom;
+  surface_buffers_map_[surface_id] = surface_buffers;
+
+  return triangleGeom;
 }
 
 ElementTreeID
@@ -359,8 +383,16 @@ std::pair<double, MeshID> GPRTRayTracer::ray_fire(SurfaceTreeID tree,
 void GPRTRayTracer::create_global_surface_tree()
 {
   // Create a TLAS (Top-Level Acceleration Structure) for all the volumes
-  auto globalBuffer = gprtDeviceBufferCreate<gprt::Instance>(context_, globalBlasInstances_.size(), globalBlasInstances_.data());
-  GPRTAccel global_accel = gprtInstanceAccelCreate(context_, globalBlasInstances_.size(), globalBuffer);
+  std::vector<gprt::Instance> globalBlasInstances;
+  globalBlasInstances.reserve(surface_to_blas_map_.size());
+  for (const auto& [surf, blas] : surface_to_blas_map_) {
+    gprt::Instance instance = gprtAccelGetInstance(blas);
+    instance.mask = 0xff;
+    globalBlasInstances.push_back(instance);
+  }
+
+  auto globalBuffer = gprtDeviceBufferCreate<gprt::Instance>(context_, globalBlasInstances.size(), globalBlasInstances.data());
+  GPRTAccel global_accel = gprtInstanceAccelCreate(context_, globalBlasInstances.size(), globalBuffer);
   gprtAccelBuild(context_, global_accel, buildParams_);
 
   SurfaceTreeID tree = next_surface_tree_id();

--- a/src/gprt/ray_tracer.cpp
+++ b/src/gprt/ray_tracer.cpp
@@ -106,84 +106,95 @@ GPRTRayTracer::create_surface_tree(const std::shared_ptr<MeshManager>& mesh_mana
   SurfaceTreeID tree = next_surface_tree_id();
   surface_trees_.push_back(tree);
   auto volume_surfaces = mesh_manager->get_volume_surfaces(volume_id);
+  auto bump = bounding_box_bump(mesh_manager, volume_id);
   std::vector<gprt::Instance> surfaceBlasInstances; // BLAS for each (surface) geometry in this volume
 
   for (const auto &surf : volume_surfaces) {
-    auto num_faces = mesh_manager->num_surface_faces(surf);
-
-    // get the sense of this surface with respect to the volume
-    Sense triangle_sense {Sense::UNSET};
-    auto surf_to_vol_senses = mesh_manager->get_parent_volumes(surf);
-    if (volume_id == surf_to_vol_senses.first) triangle_sense = Sense::FORWARD;
-    else if (volume_id == surf_to_vol_senses.second) triangle_sense = Sense::REVERSE;
-    
+    GPRTGeomOf<DPTriangleGeomData> triangleGeom;
+    GPRTAccel blas;
     DPTriangleGeomData* geom_data = nullptr;
-    auto triangleGeom = gprtGeomCreate<DPTriangleGeomData>(context_, trianglesGeomType_);
-    geom_data = gprtGeomGetParameters(triangleGeom); // pointer to assign data to
+    bool created_surface = false;
 
-    // Get storage for vertices
-    auto vertices = mesh_manager->get_surface_vertices(surf);
-    auto indices = mesh_manager->get_surface_connectivity(surf);
-    std::vector<double3> dbl3Vertices;
-    dbl3Vertices.reserve(vertices.size());    
-    for (const auto &vertex : vertices) {
-      dbl3Vertices.push_back({vertex.x, vertex.y, vertex.z});
+    if (!surface_to_geometry_map_.count(surf)) {
+      created_surface = true;
+      auto num_faces = mesh_manager->num_surface_faces(surf);
+      triangleGeom = gprtGeomCreate<DPTriangleGeomData>(context_, trianglesGeomType_);
+      geom_data = gprtGeomGetParameters(triangleGeom); // pointer to assign data to
+
+      // Get storage for vertices
+      auto vertices = mesh_manager->get_surface_vertices(surf);
+      auto indices = mesh_manager->get_surface_connectivity(surf);
+      std::vector<double3> dbl3Vertices;
+      dbl3Vertices.reserve(vertices.size());
+      for (const auto &vertex : vertices) {
+        dbl3Vertices.push_back({vertex.x, vertex.y, vertex.z});
+      }
+
+      // Get storage for indices
+      std::vector<uint3> ui3Indices;
+      ui3Indices.reserve(indices.size() / 3);
+      for (size_t i = 0; i < indices.size(); i += 3) {
+        ui3Indices.emplace_back(indices[i], indices[i + 1], indices[i + 2]);
+      }
+
+      // Get storage for normals
+      std::vector<double3> normals;
+      std::vector<GPRTPrimitiveRef> primitive_refs;
+      primitive_refs.reserve(num_faces);
+      normals.reserve(num_faces);
+      for (const auto &face : mesh_manager->get_surface_faces(surf)) {
+        auto norm = mesh_manager->face_normal(face);
+        normals.push_back({norm.x, norm.y, norm.z});
+        GPRTPrimitiveRef prim_ref;
+        prim_ref.id = face;
+        primitive_refs.push_back(prim_ref);
+      }
+
+      auto vertex_buffer = gprtDeviceBufferCreate<double3>(context_, dbl3Vertices.size(), dbl3Vertices.data());
+      auto aabb_buffer = gprtDeviceBufferCreate<float3>(context_, 2*num_faces, 0); // AABBs for each triangle
+      gprtAABBsSetPositions(triangleGeom, aabb_buffer, num_faces, 2*sizeof(float3), 0);
+      auto connectivity_buffer = gprtDeviceBufferCreate<uint3>(context_, ui3Indices.size(), ui3Indices.data());
+      auto normal_buffer = gprtDeviceBufferCreate<double3>(context_, num_faces, normals.data()); 
+      auto primitive_refs_buffer = gprtDeviceBufferCreate<GPRTPrimitiveRef>(context_, num_faces, primitive_refs.data()); // Buffer for primitive sense
+
+      geom_data->vertex = gprtBufferGetDevicePointer(vertex_buffer);
+      geom_data->index = gprtBufferGetDevicePointer(connectivity_buffer);
+      geom_data->aabbs = gprtBufferGetDevicePointer(aabb_buffer);
+      geom_data->ray = gprtBufferGetDevicePointer(rayHitBuffers_.ray);
+      geom_data->surf_id = surf;
+      geom_data->normals = gprtBufferGetDevicePointer(normal_buffer);
+      geom_data->primitive_refs = gprtBufferGetDevicePointer(primitive_refs_buffer);
+      geom_data->num_faces = num_faces;
+      geom_data->bounding_box_bump = bump;
+
+      gprtComputeLaunch(aabbPopulationProgram_, {num_faces, 1, 1}, {1, 1, 1}, *geom_data);
+      gprtComputeSynchronize(context_);
+
+      blas = gprtAABBAccelCreate(context_, triangleGeom, buildParams_.buildMode);
+      gprtAccelBuild(context_, blas, buildParams_);
+
+      surface_to_geometry_map_[surf] = triangleGeom;
+      surface_to_blas_map_[surf] = blas;
+      blas_handles_.push_back(blas);
+    } else {
+      triangleGeom = surface_to_geometry_map_.at(surf);
+      blas = surface_to_blas_map_.at(surf);
+      geom_data = gprtGeomGetParameters(triangleGeom);
+
+      if (bump > geom_data->bounding_box_bump) {
+        geom_data->bounding_box_bump = bump;
+        gprtComputeLaunch(aabbPopulationProgram_, {geom_data->num_faces, 1, 1}, {1, 1, 1}, *geom_data);
+        gprtComputeSynchronize(context_);
+        gprtAccelBuild(context_, blas, buildParams_);
+      }
     }
 
-    // Get storage for indices
-    std::vector<uint3> ui3Indices;
-    ui3Indices.reserve(indices.size() / 3);
-    for (size_t i = 0; i < indices.size(); i += 3) {
-      ui3Indices.emplace_back(indices[i], indices[i + 1], indices[i + 2]);
-    }
-
-    // Get storage for normals
-    std::vector<double3> normals;
-    std::vector<GPRTPrimitiveRef> primitive_refs;
-    primitive_refs.reserve(num_faces);
-    normals.reserve(num_faces);
-    for (const auto &face : mesh_manager->get_surface_faces(surf)) {
-      auto norm = mesh_manager->face_normal(face);
-      normals.push_back({norm.x, norm.y, norm.z});
-      GPRTPrimitiveRef prim_ref;
-      prim_ref.id = face;
-      primitive_refs.push_back(prim_ref);
-    }
-
-    auto vertex_buffer = gprtDeviceBufferCreate<double3>(context_, dbl3Vertices.size(), dbl3Vertices.data());
-    auto aabb_buffer = gprtDeviceBufferCreate<float3>(context_, 2*num_faces, 0); // AABBs for each triangle
-    gprtAABBsSetPositions(triangleGeom, aabb_buffer, num_faces, 2*sizeof(float3), 0);
-    auto connectivity_buffer = gprtDeviceBufferCreate<uint3>(context_, ui3Indices.size(), ui3Indices.data());
-    auto normal_buffer = gprtDeviceBufferCreate<double3>(context_, num_faces, normals.data()); 
-    auto primitive_refs_buffer = gprtDeviceBufferCreate<GPRTPrimitiveRef>(context_, num_faces, primitive_refs.data()); // Buffer for primitive sense
-
-    geom_data->vertex = gprtBufferGetDevicePointer(vertex_buffer);
-    geom_data->index = gprtBufferGetDevicePointer(connectivity_buffer);
-    geom_data->aabbs = gprtBufferGetDevicePointer(aabb_buffer);
-    geom_data->ray = gprtBufferGetDevicePointer(rayHitBuffers_.ray);
-    geom_data->surf_id = surf;
-    geom_data->normals = gprtBufferGetDevicePointer(normal_buffer);
-    geom_data->primitive_refs = gprtBufferGetDevicePointer(primitive_refs_buffer);
-    geom_data->num_faces = num_faces;
-    
-    gprtComputeLaunch(aabbPopulationProgram_, {num_faces, 1, 1}, {1, 1, 1}, *geom_data);
-
-    GPRTAccel blas = gprtAABBAccelCreate(context_, triangleGeom, buildParams_.buildMode);
-
-    gprtAccelBuild(context_, blas, buildParams_);
-
-    gprt::Instance instance;
-    instance = gprtAccelGetInstance(blas); // create instance of BLAS to be added to TLAS
+    gprt::Instance instance = gprtAccelGetInstance(blas);
     instance.mask = 0xff; // mask can be used to filter instances during ray traversal. 0xff ensures no filtering
-
-    // Store in maps
-    surface_to_geometry_map_[surf] = triangleGeom;
-
-    geom_data = gprtGeomGetParameters(triangleGeom);
-    instance = gprtAccelGetInstance(blas);
-    instance.mask = 0xff;
     surfaceBlasInstances.push_back(instance);
-    globalBlasInstances_.push_back(instance);
+    if (created_surface) {
+      globalBlasInstances_.push_back(instance);
+    }
     
     // Always update per-volume info
     auto [forward_parent, reverse_parent] = mesh_manager->get_parent_volumes(surf);


### PR DESCRIPTION
# Summary
This PR addresses #168 and refactors `GPRTRayTracer::create_surface_tree()` so that surface geometry setup and BLAS construction are cached per surface in the same spirit as the existing Embree implementation.

A new private method, `GPRTRayTracer::register_surface()`, now encapsulates the one-time setup for a surface:

- gather vertices, connectivity, primitive ids, and normals
- create the corresponding GPRT device buffers
- initialize the `DPTriangleGeomData` record to point at those buffers

In refactoring the logic for BLAS creation, I have also made sure that the correct bounding box bump is applied and passed to the compute kernel which constructs bounding boxes.

# Key Changes
- `register_surface()` is only called on the first visit to a surface.
- New struct to hold GPRT buffers for better lifetime management - previously host side handles weren't stored so couldn't be destroyed later
- Surface geometry and backing buffers are cached and recovered on the second visit through `surface_to_geometry_map_`and `surface_buffers_map_`.
- Surface AABBs are now populated using the maximum bounding-box bump of the two parent volumes for that surface.
- BLAS construction is now performed once per surface and cached in `surface_to_blas_map_`.
- On the second visit from the other parent volume, the implementation reuses the cached geometry and BLAS rather than rebuilding them, and only updates the per-volume tree metadata and TLAS instance list.
- Ran particle sim with a multi-volume model and results remained consistent after refactor (also agrees with Embree)