### PR TITLE
Custom Catch2 test runner

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 foreach(test ${TEST_NAMES})
     add_executable(${test} test_main.cpp ${test}.cpp)
-    target_link_libraries(${test} PRIVATE xdg fmt::fmt Catch2::Catch2WithMain)
+    target_link_libraries(${test} PRIVATE xdg fmt::fmt Catch2::Catch2)
     if (XDG_ENABLE_LIBMESH)
         target_link_libraries(${test} PRIVATE ${LIBMESH_LINK_LIBRARIES})
     endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ if (XDG_ENABLE_MOAB AND XDG_BUILD_TOOLS)
 endif()
 
 foreach(test ${TEST_NAMES})
-    add_executable(${test} ${test}.cpp)
+    add_executable(${test} test_main.cpp ${test}.cpp)
     target_link_libraries(${test} PRIVATE xdg fmt::fmt Catch2::Catch2WithMain)
     if (XDG_ENABLE_LIBMESH)
         target_link_libraries(${test} PRIVATE ${LIBMESH_LINK_LIBRARIES})

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,7 +1,6 @@
 // test_main.cpp
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch_all.hpp>
-#include <iostream>
 
 // Global tracking structure to capture test summary data safely
 struct RunSummary {
@@ -36,12 +35,11 @@ int main(int argc, char* argv[]) {
     // Run the isolated test file
     int result = session.run();
 
-    // if failures were reported, but the test runner returned 4 indicating a
-    // skipped test to Ctest, increment the return code to 5 to indicate a
-    // failure to Ctest instead
-    if (runSummary.failedAssertions > 0 && result == 4) {
-        result++;
-    }
+    // If any assersions failed, return 1 to indicate a failure to Ctest. This
+    // exists for a consistent return code to represent failures. Ctest treats a
+    // return code of four as a skipped test. Thus, four failed checks would be
+    // shown as a skipped test.
+    if (runSummary.failedAssertions > 0) return 1;
 
     return result;
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,0 +1,47 @@
+// test_main.cpp
+#define CATCH_CONFIG_RUNNER
+#include <catch2/catch_all.hpp>
+#include <iostream>
+
+// Global tracking structure to capture test summary data safely
+struct RunSummary {
+    unsigned int failedAssertions = 0;
+    unsigned int skippedTestCases = 0;
+    unsigned int executedTestCases = 0;
+} runSummary;
+
+// Create an EventListener to automatically capture Catch2 test run statistics
+struct TestInterceptor : Catch::EventListenerBase {
+    using EventListenerBase::EventListenerBase;
+
+    // This hook runs automatically when the entire test execution completes
+    void testRunEnded(Catch::TestRunStats const& testRunStats) override {
+        runSummary.failedAssertions = testRunStats.totals.assertions.failed;
+        runSummary.skippedTestCases = testRunStats.totals.testCases.skipped;
+        runSummary.executedTestCases = testRunStats.totals.testCases.total() - runSummary.skippedTestCases;
+    }
+};
+
+// Register listener with Catch2's internal registry
+CATCH_REGISTER_LISTENER(TestInterceptor)
+
+int main(int argc, char* argv[]) {
+    Catch::Session session;
+
+    int returnCode = session.applyCommandLine(argc, argv);
+    if (returnCode != 0) {
+        return returnCode;
+    }
+
+    // Run the isolated test file
+    int result = session.run();
+
+    // if failures were reported, but the test runner returned 4 indicating a
+    // skipped test to Ctest, increment the return code to 5 to indicate a
+    // failure to Ctest instead
+    if (runSummary.failedAssertions > 0 && result == 4) {
+        result++;
+    }
+
+    return result;
+}


### PR DESCRIPTION
This PR implements a custom Catch2 runner to address #234. This is pretty niche, but I could see how we'd be lucky enough to have it confuse someone who's unaware of the issue. 