### PR TITLE
Use find_package/dependency instead of include for PkgConfig

### DIFF
--- a/cmake/Modules/FindLIBMESH.cmake
+++ b/cmake/Modules/FindLIBMESH.cmake
@@ -14,7 +14,7 @@ if(DEFINED ENV{METHOD})
   message(STATUS "Using environment variable METHOD to determine libMesh build: ${LIBMESH_PC_FILE}")
 endif()
 
-include(FindPkgConfig)
+find_package(PkgConfig REQUIRED)
 set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${LIBMESH_PC}")
 set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH True)
 pkg_check_modules(LIBMESH REQUIRED ${LIBMESH_PC_FILE}>=1.7.0 IMPORTED_TARGET)

--- a/cmake/XDGConfig.cmake.in
+++ b/cmake/XDGConfig.cmake.in
@@ -16,7 +16,7 @@ if(@XDG_ENABLE_MOAB@)
 endif()
 
 if(@XDG_ENABLE_LIBMESH@)
-  include(FindPkgConfig)
+  find_dependency(PkgConfig REQUIRED)
   list(APPEND CMAKE_PREFIX_PATH @LIBMESH_PREFIX@)
   set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH True)
   pkg_check_modules(LIBMESH REQUIRED @LIBMESH_PC_FILE@>=1.7.0 IMPORTED_TARGET)


### PR DESCRIPTION
When building XDG (and building OpenMC against XDG), I was getting some warnings about package names not matching, e.g.:
```
CMake Warning (dev) at /usr/share/cmake-3.31/Modules/FindPackageHandleStandardArgs.cmake:441 (message):
  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (XDG).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/share/cmake-3.31/Modules/FindPkgConfig.cmake:114 (find_package_handle_standard_args)
  /opt/xdg/lib/cmake/xdg/XDGConfig.cmake:19 (include)
  CMakeLists.txt:165 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
This is a result of using `include(FindPkgConfig)`, which does not push a new package onto the stack, so PkgConfig's bookkeeping still thinks the current package is XDG. This is fixed by using `find_package` (in FindLIBMESH.cmake) and `find_dependency` (in XDGConfig.cmake.in), both of which do push a new package onto the stack. Note that a similar bug was fixed in openmc-dev/openmc#3119.