### PR TITLE
Changing fmt and indicators dependency handling for downstream projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ endif()
 
 # fmt
 if (NOT fmt_FOUND)
-  set(FMT_INSTALL ON CACHE BOOL "Generate the fmt install target")
+  set(FMT_INSTALL OFF CACHE BOOL "Generate the fmt install target")
   add_subdirectory(vendor/fmt)
 endif()
 message(STATUS "Using fmt ${fmt_VERSION} at ${fmt_DIR}")
@@ -410,3 +410,8 @@ install(FILES
 )
 
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+if (NOT fmt_FOUND)
+  install(DIRECTORY ${CMAKE_SOURCE_DIR}/vendor/fmt/include/
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()

--- a/cmake/XDGConfig.cmake.in
+++ b/cmake/XDGConfig.cmake.in
@@ -22,10 +22,6 @@ if(@XDG_ENABLE_LIBMESH@)
   pkg_check_modules(LIBMESH REQUIRED @LIBMESH_PC_FILE@>=1.7.0 IMPORTED_TARGET)
 endif()
 
-if(NOT TARGET fmt::fmt)
-  find_dependency(fmt CONFIG REQUIRED HINTS "${_XDG_PREFIX}")
-endif()
-
 if(NOT TARGET indicators::indicators)
   find_dependency(indicators CONFIG REQUIRED HINTS "${_XDG_PREFIX}")
 endif()

--- a/cmake/XDGConfig.cmake.in
+++ b/cmake/XDGConfig.cmake.in
@@ -22,8 +22,10 @@ if(@XDG_ENABLE_LIBMESH@)
   pkg_check_modules(LIBMESH REQUIRED @LIBMESH_PC_FILE@>=1.7.0 IMPORTED_TARGET)
 endif()
 
-if(NOT TARGET indicators::indicators)
-  find_dependency(indicators CONFIG REQUIRED HINTS "${_XDG_PREFIX}")
+if(@XDG_BUILD_TOOLS@)
+  if(NOT TARGET indicators::indicators)
+    find_dependency(indicators CONFIG REQUIRED HINTS "${_XDG_PREFIX}")
+  endif()
 endif()
 
 if(@XDG_LINK_MPI@)


### PR DESCRIPTION
Issue 1:  
XDG currently handles fmt by:
 1. Installing its vendored fmt (v8.0.1) to the shared install prefix (`FMT_INSTALL=ON`)
 2. Re-exporting fmt via `find_dependency(fmt)` in XDGConfig.cmake so `find_package(XDG)` would trigger fmt discovery
This installs a versioned fmtConfig.cmake, which causes errors/version mismatches when a downstream project runs find_package(fmt).

(Specifically, I am testing a new Cardinal branch that was using the OpenMC branch with XDG).

When the downstream project (OpenMC) ran `find_package(fmt)`, it discovered XDG's installed fmt v8 instead of its own, compiled against v8 headers, and then failed to link because its own fmt library was a different version. This produced linker errors during the OpenMC build:  
 undefined reference to `fmt::v10::vprint(...)'
 undefined reference to `fmt::v10::detail::is_printable(unsigned int)'  

Changes:  

In CMakeLists.txt:  

 - Set `FMT_INSTALL OFF` so fmt's cmake config and library are not installed to the shared prefix. This prevents downstream `find_package(fmt)` from discovering a stale, potentially version-mismatched fmt.
 - Installed fmt's headers only with XDG's own headers. This ensures consumers can `#include <fmt/format.h>` through XDG's public include path without needing a separate fmt cmake package. Only applies when XDG is using its own vendored fmt (i.e. `NOT fmt_FOUND`).

In cmake/XDGConfig.cmake.in:  

 - Removed `find_dependency(fmt)`. fmt headers are now included with XDG's install (above change), so consumers don't need cmake to locate fmt. Downstream projects that link their own fmt library can do so independently without version conflicts.


Issue 2:  
`find_dependency(indicators)` was called unconditionally in XDGConfig.cmake, but I believe indicators is only used by XDG CLI tools. When `XDG_BUILD_TOOLS=OFF`, indicators is not installed, so `find_package(XDG)` was causing the build to break when tools are off.  

Changes:  
Put `find_dependency(indicators)` in a conditional based on `XDG_BUILD_TOOLS`.


After I made these changes, OpenMC built w/XDG and there were no linkage issues to fmt or indicators.